### PR TITLE
Partial rewrite of ShapeDNA module

### DIFF
--- a/examples/Test_ShapeDNA.ipynb
+++ b/examples/Test_ShapeDNA.ipynb
@@ -6,19 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Freesurfer 6.0 needs to be sourced prior to starting this server / notebook\n",
-    "import os\n",
-    "FS_HOME = os.getenv(\"FREESURFER_HOME\")\n",
-    "SUB_DIR = os.getenv(\"SUBJECTS_DIR\")\n",
-    "OUT_DIR = os.getcwd()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "from lapy import TriaIO\n",
+    "from lapy import TetIO\n",
     "from lapy import ShapeDNA"
    ]
   },
@@ -28,12 +17,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# we will be using one of the Freesurfer-provided MR images, and compute the \n",
-    "# ShapeDNA descriptor for the left hippocampus (aseg id 17). We will use a \n",
-    "# subdirectory of the current directory as output directory, since the \n",
-    "# Freesurfer directory will not necessarily have write access\n",
-    "OUT_DIR_1 = os.path.join(OUT_DIR, \"test_1\")\n",
-    "ShapeDNA.compute_ShapeDNA(sid=\"bert\", sdir=SUB_DIR, outdir=OUT_DIR_1, asegid=[\"17\"])"
+    "tria = TriaIO.import_vtk(\"../data/cubeTria.vtk\")\n",
+    "tet = TetIO.import_vtk(\"../data/cubeTetra.vtk\")"
    ]
   },
   {
@@ -42,14 +27,96 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# we will be using one of the Freesurfer-provided MR images, and compute the \n",
-    "# ShapeDNA descriptor for the left white matter surface. \n",
-    "# We will use a subdirectory of the current directory as output directory, \n",
-    "# since the Freesurfer directory will not necessarily have write access.\n",
-    "OUT_DIR_2 = os.path.join(OUT_DIR, \"test_2\")\n",
-    "SURF_FILE = os.path.join(SUB_DIR, \"bert\", \"surf\", \"lh.white\")\n",
-    "ShapeDNA.compute_ShapeDNA(sid=\"bert\", sdir=SUB_DIR, outdir=OUT_DIR_2, surf=SURF_FILE)"
+    "ShapeDNA.compute_shapedna(tria, k=3)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ShapeDNA.compute_shapedna(tria, k=3, norm=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ShapeDNA.compute_shapedna(tria, k=3, rwt=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ShapeDNA.compute_shapedna(tet, k=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ShapeDNA.compute_shapedna(tet, k=3, norm=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ShapeDNA.compute_shapedna(tet, k=3, rwt=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ShapeDNA.compute_asymmetry(tria, tria)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ShapeDNA.compute_asymmetry(tria, tria, norm=True, rwt=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ShapeDNA.compute_asymmetry(tet, tet)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ShapeDNA.compute_asymmetry(tet, tet, norm=True, rwt=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/Test_ShapeDNA.ipynb
+++ b/examples/Test_ShapeDNA.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# imports\n",
     "from lapy import TriaIO\n",
     "from lapy import TetIO\n",
     "from lapy import ShapeDNA"
@@ -17,6 +18,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# load data\n",
     "tria = TriaIO.import_vtk(\"../data/cubeTria.vtk\")\n",
     "tet = TetIO.import_vtk(\"../data/cubeTetra.vtk\")"
    ]
@@ -27,7 +29,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ShapeDNA.compute_shapedna(tria, k=3)"
+    "# compute eigenvalues and eigenvectors for tria mesh\n",
+    "ev = ShapeDNA.compute_shapedna(tria, k=3)\n",
+    "ev['Eigenvectors']\n",
+    "ev['Eigenvalues']"
    ]
   },
   {
@@ -36,7 +41,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ShapeDNA.compute_shapedna(tria, k=3, norm=True)"
+    "# volume / surface / geometry normalization of tria eigenvalues\n",
+    "ShapeDNA.normalize_ev(tria, ev[\"Eigenvalues\"], method=\"geometry\")"
    ]
   },
   {
@@ -45,7 +51,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ShapeDNA.compute_shapedna(tria, k=3, rwt=True)"
+    "# linear reweighting of tria eigenvalues\n",
+    "ShapeDNA.reweight_ev(ev[\"Eigenvalues\"])"
    ]
   },
   {
@@ -54,7 +61,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ShapeDNA.compute_shapedna(tet, k=3)"
+    "# compute distance for tria eigenvalues (trivial case)\n",
+    "ShapeDNA.compute_distance(ev[\"Eigenvalues\"], ev[\"Eigenvalues\"])"
    ]
   },
   {
@@ -63,7 +71,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ShapeDNA.compute_shapedna(tet, k=3, norm=True)"
+    "# compute eigenvalues and eigenvectors for tet mesh\n",
+    "evTet = ShapeDNA.compute_shapedna(tet, k=3)\n",
+    "evTet['Eigenvectors']\n",
+    "evTet['Eigenvalues']"
    ]
   },
   {
@@ -72,7 +83,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ShapeDNA.compute_shapedna(tet, k=3, rwt=True)"
+    "# volume / surface / geometry normalization of tet eigenvalues\n",
+    "ShapeDNA.normalize_ev(tet, evTet[\"Eigenvalues\"], method=\"geometry\")"
    ]
   },
   {
@@ -81,7 +93,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ShapeDNA.compute_asymmetry(tria, tria)"
+    "# linear reweighting of tet eigenvalues\n",
+    "ShapeDNA.reweight_ev(evTet[\"Eigenvalues\"])"
    ]
   },
   {
@@ -90,25 +103,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ShapeDNA.compute_asymmetry(tria, tria, norm=True, rwt=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ShapeDNA.compute_asymmetry(tet, tet)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ShapeDNA.compute_asymmetry(tet, tet, norm=True, rwt=True)"
+    "# compute distance for tria eigenvalues (trivial case)\n",
+    "ShapeDNA.compute_distance(evTet[\"Eigenvalues\"], evTet[\"Eigenvalues\"])"
    ]
   },
   {

--- a/lapy/FuncIO.py
+++ b/lapy/FuncIO.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def import_vfunc(infile):
+def import_vfunc_deprecated(infile):
     """
     Imports vertex function from txt file. Values can be separated by ; or ,
     and surrounded by {} or () brackets. Also first line can have the
@@ -30,6 +30,40 @@ def import_vfunc(infile):
             # del (tmp1, tmp2)
         i = i + 1
     return vals
+
+
+def import_vfunc(filename):
+    """
+    Imports vertex function from txt file. Values can be separated by ; or ,
+    and surrounded by {} or () brackets. Also first line can have the
+    keyword "Solution:", i.e. the PSOL format from ShapeDNA
+    """
+
+    import re
+    import numpy as np
+
+    try:
+        with open(filename) as f:
+            txt = f.readlines()
+    except IOError:
+        print("[File " + infile + " not found or not readable]")
+        return
+
+    txt = [ x.strip() for x in txt ]
+
+    txt.remove("Solution:")
+
+    txt = [ re.sub("[{()}]",'', x) for x in txt ]
+
+    if len(txt) == 1:
+
+        txt = [ re.split("[,;]", x) for x in txt ][0]
+
+    txt = [ np.float(x) for x in txt ]
+
+    #txt = np.array(txt)
+
+    return txt
 
 
 def import_ev(infile):

--- a/lapy/ShapeDNA.py
+++ b/lapy/ShapeDNA.py
@@ -68,11 +68,19 @@ def normalize_ev(geom, evals, method="geometry"):
 
     elif method == "volume":
 
-        bnd = geom.boundary_tria()
+        if type(geom).__name__ == "TriaMesh":
 
-        bnd.orient_()
+            geom.orient_()
 
-        vol = bnd.volume()
+            vol = geom.volume()
+
+        elif type(geom).__name__ == "TetMesh":
+
+            bnd = geom.boundary_tria()
+
+            bnd.orient_()
+
+            vol = bnd.volume()
 
         return evals * vol ** np.divide(2.0, 3.0)
 

--- a/lapy/ShapeDNA.py
+++ b/lapy/ShapeDNA.py
@@ -1,498 +1,123 @@
-"""
+import numpy as np
+import scipy.spatial.distance as di
+from .TriaMesh import TriaMesh
+from .TetMesh import TetMesh
+from .Solver import Solver
 
-shapeDNA - a script to compute ShapeDNA of FreeSurfer structures
-
-SUMMARY
-=======
-
-Computes surface (and volume) models of FreeSurfer's subcortical and cortical
-structures and computes a spectral shape descriptor (ShapeDNA [1]).
-
-Use the 'compute_ShapeDNA' function to compute the shapeDNA descriptor.
-
-Required arguments are:
-
-'sid'     : subject ID
-'sdir'    : subjects directory
-
-Input can be (exactly) one of the following:
-
-'asegid'  : an aseg label id to construct a surface of that ROI
-'hsfid'   : a hippocampal subfields id to construct a surface of that ROI (also pass 'hemi')
-'surf'    : a surface, e.g. lh.white
-
-Note that FreeSurfer needs to be sourced for this program to run.
-
-EXAMPLE
-=======
-
-ShapeDNA.compute_ShapeDNA(sid="mySubjectID", sdir="/my/subjects/directory", outdir="/my/output/directory", asegid=["17"])
-
-ARGUMENTS
-=========
-
-REQUIRED ARGUMENTS
-
-'sid' <name>      Subject ID
-
-'sdir' <name>     Subjects directory
-
-One of the following:
-
-'asegid' <int>    Segmentation ID of structure in aseg.mgz (e.g. 17 is
-                  Left-Hippocampus), for ID's check <sid>/stats/aseg.stats
-                  or $FREESURFER_HOME/FreeSurferColorLUT.txt.
-
-'hsfid' <int>     Segmentation ID of structure in
-                  [lr]h.<segmentation>Labels-<label>.<version><suffix>
-                  For ID's (e.g. 206 is CA1) check compressionLookupTable.txt
-                  in $FREESURFER_HOME/average/HippoSF/atlas. Also specify
-                  'hemi' if using this argument.
-
-'surf' <name>     lh.pial, rh.pial, lh.white, rh.white etc. to select a
-                  surface from the <sid>/surfs directory.
-
-OPTIONAL ARGUMENT
-
-'outdir' <name>   Output directory (default: <sdir>/<sid>/shapedna/)
-
-REQUIRED ARGUMENT if using 'hsfid'
-
-'hemi' <name>     'lh' or 'rh' hemisphere
-
-OPTIONAL ARGUMENTS if using 'hsfid'
-
-'hsflabel' <name> Label of hippocampal subfield segmentation, e.g. T1 or
-                  T1-T1T2_HC_segmentation (default: T1)
-
-'hsfver' <name>   Version of hippocampal subfield segmentation, e.g v10 or
-                  v20 (default: v10)
-
-'hsfseg' <name>   Name of segmentation, e.g. hippoSf or hippoAmyg (default:
-                  hippoSf)
-
-'hsfsfx' <name>   Suffix of segmenation, e.g. FSvoxelSpace or none (specify
-                  as '') (default: FSvoxelSpace)
-
-ShapeDNA parameters:
-
-'num' <int>       Number of eigenvalues/vectors to compute (default: 50)
-
-'bcond' <int>     Boundary condition (0=Dirichlet, 1=Neumann default)
-
-'evec'            Additionally compute eigenvectors
-
-
-REFERENCES
-==========
-
-Always cite [1] as it describes the method. If you use topological features of
-eigenfunctions, also cite [2]. [3] compares different discretizations of
-Laplace-Beltrami operators and shows that the used FEM appraoch performs best.
-If you do statistical shape analysis you may also want to cite [4] as it
-discusses medical applications.
-
-[1] M. Reuter, F.-E. Wolter and N. Peinecke.
-Laplace-Beltrami spectra as "Shape-DNA" of surfaces and solids.
-Computer-Aided Design 38 (4), pp.342-366, 2006.
-http://dx.doi.org/10.1016/j.cad.2005.10.011
-
-[2] M. Reuter. Hierarchical Shape Segmentation and Registration
-via Topological Features of Laplace-Beltrami Eigenfunctions.
-International Journal of Computer Vision, 2009.
-http://dx.doi.org/10.1007/s11263-009-0278-1
-
-[3] M. Reuter, S. Biasotti, D. Giorgi, G. Patane, M. Spagnuolo.
-Discrete Laplace-Beltrami operators for shape analysis and
-segmentation. Computers & Graphics 33 (3), pp.381-390, 2009.
-http://dx.doi.org/10.1016/j.cag.2009.03.005
-
-[4] M. Reuter, F.-E. Wolter, M. Shenton, M. Niethammer.
-Laplace-Beltrami Eigenvalues and Topological Features of
-Eigenfunctions for Statistical Shape Analysis.
-Computer-Aided Design 41 (10), pp.739-755, 2009.
-http://dx.doi.org/10.1016/j.cad.2009.02.007
-
-"""
-# ==============================================================================
-# FUNCTIONS
-
-# ------------------------------------------------------------------------------
-# auxiliary functions
-
-# function to run commands
-def run_cmd(cmd, err_msg):
+# compute shapeDNA
+def compute_shapedna(geom, k=50, lump=False, aniso=None, aniso_smooth=10,
+    norm=False, rwt=False):
     """
-    execute the command
+    a function to compute the shapeDNA descriptor for triangle or tetrahedral
+    meshes
+
+    Inputs:     geom        geometry; either TriaMesh or TetMesh
+                k           number of eigenfunctions / eigenvalues
+                lump, aniso, aniso_smooth
+                            arguments for 'Solver' class
+                norm        whether to perform area / volume normalization
+                rwt         whether to perform linear reweighting
+
+    :return:    ev          a dictionary, including 'Eigenvalues' and
+                            'Eigenvectors' fields
+
     """
-
-    # imports
-    import os
-    import sys
-    import shlex
-    import subprocess
-
-    # aux function
-    def which(program):
-        """
-        check if executable
-        """
-
-        # aux function
-        def is_exe(fpath):
-            return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-        fpath, fname = os.path.split(program)
-
-        if fpath:
-            if is_exe(program):
-                return program
-        else:
-            for path in os.environ["PATH"].split(os.pathsep):
-                path = path.strip('"')
-                exe_file = os.path.join(path, program)
-                if is_exe(exe_file):
-                    return exe_file
-            if is_exe(os.path.join('.', program)):
-                return os.path.join('.', program)
-
-        return None
-
-    clist = cmd.split()
-    progname = which(clist[0])
-    if progname is None:
-        print('ERROR: ' + clist[0] + ' not found in path!', flush=True)
-        sys.exit(1)
-    clist[0] = progname
-    cmd = ' '.join(clist)
-    print('#@# Command: ' + cmd + '\n', flush=True)
-
-    args = shlex.split(cmd)
-    try:
-        subprocess.check_call(args)
-    except subprocess.CalledProcessError as e:
-        print('ERROR: ' + err_msg, flush=True)
-        raise
-
-# ------------------------------------------------------------------------------
-# check options
-
-# check_options
-def check_options(options):
-    """
-    checks if input options are valid, and sets some defaults
-    """
-
-    # imports
-    import os
-    import sys
-    import tempfile
-    import uuid
-    import errno
-
-    # check if Freesurfer has been sourced
-    fshome = os.getenv('FREESURFER_HOME')
-    if fshome is None:
-        print('\nERROR: Environment variable FREESURFER_HOME not set. \n', flush=True)
-        print('       Make sure to source your FreeSurfer installation.\n', flush=True)
-        sys.exit(1)
-
-    # subjects dir must be given
-    if options["sdir"] is None:
-        print('\nERROR: specify subjects directory via --sdir\n', flush=True)
-        sys.exit(1)
-
-    # subject id must be given and exist in subjects dir
-    if options["sid"] is None:
-        print('\nERROR: Specify --sid\n', flush=True)
-        sys.exit(1)
-
-    subjdir = os.path.join(options["sdir"], options["sid"])
-    if not os.path.exists(subjdir):
-        print('ERROR: cannot find sid in subjects directory\n', flush=True)
-        sys.exit(1)
-
-    # input needs to be either a surf or aseg or hipposf label(s)
-    if options["asegid"] is None and options["surf"] is None and options["hsfid"] is None:
-        print('\nERROR: Specify either --asegid or --hsfid or --surf\n', flush=True)
-        sys.exit(1)
-
-    # and it cannot be more than one of them
-    if sum((options["asegid"] is not None, options["surf"] is not None, options["hsfid"] is not None)) > 1:
-        print('\nERROR: Specify either --asegid or --hsfid or --surf (not more than one of them)\n', flush=True)
-        sys.exit(1)
-
-    # check format of asegid
-    if type(options["asegid"]) is str:
-        options["asegid"] = [ options["asegid"] ]
-    elif type(options["asegid"]) is int:
-        options["asegid"] = [ str(options["asegid"]) ]
-    elif type(options["asegid"]) is list:
-        options["asegid"] = [ str(x) for x in options["asegid"] ]
-    elif type(options["asegid"]) is tuple:
-        options["asegid"] = [ str(x) for x in options["asegid"] ]
-
-    # check format of hsfid
-    if type(options["hsfid"]) is str:
-        options["hsfid"] = [ options["hsfid"] ]
-    elif type(options["hsfid"]) is int:
-        options["hsfid"] = [ str(options["hsfid"]) ]
-    elif type(options["hsfid"]) is list:
-        options["hsfid"] = [ str(x) for x in options["hsfid"] ]
-    elif type(options["hsfid"]) is tuple:
-        options["hsfid"] = [ str(x) for x in options["hsfid"] ]
-
-    # if --hsfid is used, then also --hemi needs to be specified
-    if options["hsfid"] is not None and options["hemi"] is None:
-        print('\nERROR: Specify --hemi\n', flush=True)
-        sys.exit(1)
-
-    # hemi needs to be either lh or rh
-    if options["hemi"] is not None and options["hemi"] != "lh" and options["hemi"] != "rh":
-        print('\nERROR: Specify either --hemi=lh or --hemi=rh\n', flush=True)
-        sys.exit(1)
-
-    # check suffix to start with a point
-    if options["hsfsfx"] is not None and options["hsfsfx"][0] is not ".":
-        options["hsfsfx"] = "." + options["hsfsfx"]
-        print(options["hsfsfx"])
-
-    # check if required files are present for --hsfid
-    if options["hsfid"] is not None and options["hemi"] == "lh" and not os.path.isfile(os.path.join(options["sdir"], options["sid"], 'mri', 'lh.' + options["hsfseg"] + 'Labels-' + options["hsflabel"] + '.' + options["hsfver"] + options["hsfsfx"] + '.mgz')):
-        print('\nERROR: could not find ' + os.path.join(options["sdir"], options["sid"], 'mri', 'lh.' + options["hsfseg"] + 'Labels-' + options["hsflabel"] + '.' + options["hsfver"] + options["hsfsfx"] + '.mgz') + '\n', flush=True)
-        sys.exit(1)
-
-    if options["hsfid"] is not None and options["hemi"] == "rh" and not os.path.isfile(os.path.join(options["sdir"], options["sid"], 'mri', 'rh.' + options["hsfseg"] + 'Labels-' + options["hsflabel"] + '.' + options["hsfver"] + options["hsfsfx"] + '.mgz')):
-        print('\nERROR: could not find ' + os.path.join(options["sdir"], options["sid"], 'mri', 'rh.' + options["hsfseg"] + 'Labels-' + options["hsflabel"] + '.' + options["hsfver"] + options["hsfsfx"] + '.mgz') + '\n', flush=True)
-        sys.exit(1)
-
-    # set default output dir
-    if options["outdir"] is None:
-        options["outdir"] = os.path.join(subjdir, 'shapedna')
-    try:
-        os.mkdir(options["outdir"])
-    except OSError as e:
-        if e.errno != errno.EEXIST:  # directory exists (but that's OK)
-            raise e
-        pass
-
-    # check if we have write access to output dir
-    try:
-        testfile = tempfile.TemporaryFile(dir=options["outdir"])
-        testfile.close()
-    except OSError as e:
-        if e.errno != errno.EACCES:  # 13
-            e.filename = options["outdir"]
-            raise
-        print('\nERROR: ' + options["outdir"] + ' not writeable (check access)!\n', flush=True)
-        sys.exit(1)
-
-    # initialize outsurf
-    if options["asegid"] is not None:
-        astring = '_'.join(options["asegid"])
-        surfname = 'aseg.' + astring + '.vtk'
-        options["outsurf"] = os.path.join(options["outdir"], surfname)
-    elif options["hsfid"] is not None:
-        astring = str(options["hemi"]) + '-' + '_'.join(options["hsfid"])
-        surfname = 'hsf.' + astring + '.vtk'
-        options["outsurf"] = os.path.join(options["outdir"], surfname)
-    else:
-        # for other surfaces, a refined/smoothed version could be written
-        surfname = os.path.basename(options["surf"]) + '.vtk'
-        options["outsurf"] = os.path.join(options["outdir"], surfname)
-
-    return options
-
-# ------------------------------------------------------------------------------
-# image and surface processing functions
-
-# creates a surface from the aseg and label info and writes it to the outdir
-def get_aseg_surf(options):
-    """
-    a function to create a surface from the aseg and label files
-    """
-
-    # imports
-    import os
-    import uuid
-
-    #
-    astring = ' '.join(options["asegid"])
-    subjdir = os.path.join(options["sdir"], options["sid"])
-    aseg = os.path.join(subjdir, 'mri', 'aseg.mgz')
-    norm = os.path.join(subjdir, 'mri', 'norm.mgz')
-    tmpname = 'aseg.' + str(uuid.uuid4())
-    segf = os.path.join(options["outdir"], tmpname + '.mgz')
-    segsurf = os.path.join(options["outdir"], tmpname + '.surf')
-    # binarize on selected labels (creates temp segf)
-    # always binarize first, otherwise pretess may scale aseg if labels are larger than 255 (e.g. aseg+aparc, bug in mri_pretess?)
-    cmd = 'mri_binarize --i ' + aseg + ' --match ' + astring + ' --o ' + segf
-    run_cmd(cmd, 'mri_binarize failed.')
-    ptinput = segf
-    ptlabel = '1'
-    # if norm exist, fix label (pretess)
-    if os.path.isfile(norm):
-        cmd = 'mri_pretess ' + ptinput + ' ' + ptlabel + ' ' + norm + ' ' + segf
-        run_cmd(cmd, 'mri_pretess failed.')
-    else:
-        if not os.path.isfile(segf):
-            # cp segf if not exist yet (it exists already if we combined labels above)
-            cmd = 'cp ' + ptinput + ' ' + segf
-            run_cmd(cmd, 'cp segmentation file failed.')
-    # runs marching cube to extract surface
-    cmd = 'mri_mc ' + segf + ' ' + ptlabel + ' ' + segsurf
-    run_cmd(cmd, 'mri_mc failed?')
-    # convert to vtk
-    cmd = 'mris_convert ' + segsurf + ' ' + options["outsurf"]
-    run_cmd(cmd, 'mris_convert failed.')
-    # return surf name
-    return options["outsurf"]
-
-# creates a surface from the hsf and label info and writes it to the outdir
-def get_hsf_surf(options):
-    """
-    a function to create surfaces from hsf masks and labels
-    """
-
-    # imports
-    import os
-    import sys
-    import uuid
-
-    #
-    astring = ' '.join(options["hsfid"])
-    subjdir = os.path.join(options["sdir"], options["sid"])
-    hsf = os.path.join(options["sdir"], options["sid"], 'mri', options["hemi"] + '.' + options["hsfseg"] + 'Labels-' + options["hsflabel"] + '.' + options["hsfver"] + options["hsfsfx"] + '.mgz')
-    print('Creating surfaces from ' + hsf, flush=True)
-    if not os.path.isfile(hsf):
-        print('\nERROR: could not open ' + hsf + "\n", flush=True)
-        sys.exit(1)
-    norm = os.path.join(subjdir, 'mri', 'norm.mgz')
-    tmpname = 'hsf.' + str(uuid.uuid4())
-    segf = os.path.join(options["outdir"], tmpname + '.mgz')
-    segsurf = os.path.join(options["outdir"], tmpname + '.surf')
-    # binarize on selected labels (creates temp segf)
-    # always binarize first, otherwise pretess may scale aseg if labels are larger than 255 (e.g. aseg+aparc, bug in mri_pretess?)
-    cmd = 'mri_binarize --i ' + hsf + ' --match ' + astring + ' --o ' + segf
-    run_cmd(cmd, 'mri_binarize failed.')
-    ptinput = segf
-    ptlabel = '1'
-    # if norm exist, fix label (pretess)
-    if os.path.isfile(norm):
-        cmd = 'mri_pretess ' + ptinput + ' ' + ptlabel + ' ' + norm + ' ' + segf
-        run_cmd(cmd, 'mri_pretess failed.')
-    else:
-        if not os.path.isfile(segf):
-            # cp segf if not exist yet (it exists already if we combined labels above)
-            cmd = 'cp ' + ptinput + ' ' + segf
-            run_cmd(cmd, 'cp segmentation file failed.')
-    # runs marching cube to extract surface
-    cmd = 'mri_mc ' + segf + ' ' + ptlabel + ' ' + segsurf
-    run_cmd(cmd, 'mri_mc failed?')
-    # convert to vtk
-    cmd = 'mris_convert ' + segsurf + ' ' + options["outsurf"]
-    run_cmd(cmd, 'mris_convert failed.')
-    # return surf name
-    return options["outsurf"]
-
-# gets global path to surface input (if it is a FS surf)
-def get_surf_surf(options):
-    """
-    a function to return a surface name
-    """
-
-    # imports
-    import os
-
-    # check if surface has VTK format
-    if (os.path.splitext(options["surf"])[1]).upper() != '.VTK':
-        print("Converting surface "+options["surf"]+" to vtk format ...")
-        cmd = 'mris_convert ' + options["surf"] + ' ' + options["outsurf"]
-        run_cmd(cmd, 'mris_convert failed.')
-
-    # return surf name
-    return options["outsurf"]
-
-# ------------------------------------------------------------------------------
-# shapeDNA functions
-
-# run shapeDNA-tria
-def compute_shapeDNA_tria(surf, options):
-    """
-    a function to compute the shapeDNA descriptor for triangle meshes
-    """
-
-    # imports
-    from lapy import TriaIO, FuncIO, Solver
-
-    # get surface
-    tria = TriaIO.import_vtk(surf)
 
     # get fem, evals, evecs
-    fem = Solver(tria)
-    evals, evecs = fem.eigs(k=options['num'])
+
+    fem = Solver(geom, lump=lump, aniso=aniso, aniso_smooth=aniso_smooth)
+    evals, evecs = fem.eigs(k=k)
+
+    # surface / volume normalization
+
+    if norm is True:
+
+        evals = _surf_vol_norm(geom, evals)
+
+    # linear reweighting
+
+    if rwt is True:
+
+        evals = _linear_reweighting(evals)
 
     # write ev
 
     evDict = dict()
     evDict['Refine'] = 0
     evDict['Degree'] = 1
-    evDict['Dimension'] = 2
-    evDict['Elements'] = len(tria.t)
-    evDict['DoF'] = len(tria.v)
-    evDict['NumEW'] = options["num"]
+    if type(geom).__name__ == "TriaMesh":
+        evDict['Dimension'] = 2
+    elif type(geom).__name__ == "TetMesh":
+        evDict['Dimension'] = 3
+    evDict['Elements'] = len(geom.t)
+    evDict['DoF'] = len(geom.v)
+    evDict['NumEW'] = k
     evDict['Eigenvalues'] = evals
     evDict['Eigenvectors'] = evecs
 
-    outev = options["outsurf"] + '.ev'
-
-    FuncIO.export_ev(outev, evDict)
-
-    # write surf
-
-    TriaIO.export_vtk(tria, options["outsurf"])
-
     # return
 
-    return tria, evals, evecs
+    return evDict
 
-# ------------------------------------------------------------------------------
-# main function
 
-# compute_ShapeDNA
-def compute_ShapeDNA(sid=None, sdir=None, outdir=None, asegid=None, surf=None, hemi=None, hsfid=None, hsflabel=None, hsfver=None, hsfseg=None, hsfsfx=None, num=50, bcond=1, evec=False):
+# compute shape asysmmetry
+
+def compute_asymmetry(geom1, geom2, dist="euc", k=50, lump=False, aniso=None,
+    aniso_smooth=10, norm=False, rwt=False):
     """
-    the main function to compute the ShapeDNA descriptor
+    a function to compute the shape asymmetry from two shapeDNA descriptors
+    for triangle or tetrahedral meshes
+
+    Inputs:     geom1, geom2
+                            geometries; either TriaMesh or TetMesh
+                distance    distance measure; currently only 'euc' (euclidean)
+                k           number of eigenfunctions / eigenvalues
+                lump, aniso, aniso_smooth
+                            arguments for 'Solver' class
+                norm        whether to perform area / volume normalization
+                rwt         whether to perform linear reweighting
+
+    :return:    dst          a distance measure
 
     """
 
-    # imports
-    import os
-    import sys
-    import warnings
+    ev1 = compute_shapedna(geom1, k=k, lump=lump, aniso=aniso,
+        aniso_smooth=aniso_smooth, norm=norm, rwt=rwt)
 
-    # get options
-    options = dict(sid=sid, sdir=sdir, outdir=outdir, asegid=asegid, hsfid=hsfid, surf=surf, hemi=hemi, hsflabel=hsflabel, hsfver=hsfver, hsfseg=hsfseg, hsfsfx=hsfsfx, num=num, bcond=bcond, evec=evec)
+    ev2 = compute_shapedna(geom2, k=k, lump=lump, aniso=aniso,
+        aniso_smooth=aniso_smooth, norm=norm, rwt=rwt)
 
-    # check command line options
-    options = check_options(options)
-
-    # get surface
-    if options["asegid"] is not None:
-        surf = get_aseg_surf(options)
-        outsurf = surf
-    elif options["hsfid"] is not None:
-        surf = get_hsf_surf(options)
-        outsurf = surf
-    elif options["surf"] is not None:
-        surf = get_surf_surf(options)
-        outsurf = options["outsurf"]
+    if dist == "euc":
+        return di.euclidean(ev1["Eigenvalues"][1:], ev2["Eigenvalues"][1:])
     else:
-        surf = None
+        print("Only euclidean distance is currently implemented.")
+        return
 
-    if surf is None:
-        print('\nERROR: no surface was created/selected?\n', flush=True)
-        sys.exit(1)
+# internal function for surface / volume normalization
 
-    # run shapeDNA tria
-    tria, evals, evecs = compute_shapeDNA_tria(surf, options)
+def _surf_vol_norm(geom, evals):
+
+    if type(geom).__name__ == "TriaMesh":
+
+        vol = geom.area()
+
+        return evals * vol ** np.divide(2.0, 2.0)
+
+
+    elif type(geom).__name__ == "TetMesh":
+
+        bnd = geom.boundary_tria()
+
+        bnd.orient_()
+
+        vol = bnd.volume()
+
+        return evals * vol ** np.divide(2.0, 3.0)
+
+# internal function linear reweighting
+
+def _linear_reweighting(evals):
+
+    evals[1:] = evals[1:] / np.arange(1, len(evals))
+
+    return evals

--- a/lapy/ShapeDNA.py
+++ b/lapy/ShapeDNA.py
@@ -113,7 +113,8 @@ def reweight_ev(evals):
     :return:    evals        vector of reweighted eigenvalues
     """
 
-    evals[1:] = evals[1:] / np.arange(1, len(evals))
+    #evals[1:] = evals[1:] / np.arange(1, len(evals))
+    evals = evals / np.arange(1, len(evals)+1)
 
     return evals
 

--- a/lapy/ShapeDNA.py
+++ b/lapy/ShapeDNA.py
@@ -124,7 +124,7 @@ def compute_distance(ev1, ev2, dist="euc"):
     """
 
     if dist == "euc":
-        return di.euclidean(ev1["Eigenvalues"][1:], ev2["Eigenvalues"][1:])
+        return di.euclidean(ev1, ev2)
     else:
         print("Only euclidean distance is currently implemented.")
         return

--- a/lapy/TetIO.py
+++ b/lapy/TetIO.py
@@ -119,14 +119,14 @@ def import_vtk(infile):
         return
     # expect Dataset Polydata line after ASCII:
     line = f.readline()
-    if not line.startswith("DATASET POLYDATA"):
-        print("[read: " + line + " expected DATASET POLYDATA] --> FAILED\n")
+    if not line.startswith("DATASET POLYDATA") and not line.startswith("DATASET UNSTRUCTURED_GRID"):
+        print("[read: " + line + " expected DATASET POLYDATA or DATASET UNSTRUCTURED_GRID] --> FAILED\n")
         return
     # read number of points
     line = f.readline()
     larr = line.split()
-    if larr[0] != "POINTS" or larr[2] != "float":
-        print("[read: " + line + " expected POINTS # float] --> FAILED\n")
+    if larr[0] != "POINTS" or (larr[2] != "float" and larr[2] != "double"):
+        print("[read: " + line + " expected POINTS # float or POINTS # double ] --> FAILED\n")
         return
     pnum = int(larr[1])
     # read points as chunk
@@ -135,7 +135,7 @@ def import_vtk(infile):
     # expect polygon or tria_strip line
     line = f.readline()
     larr = line.split()
-    if larr[0] == "POLYGONS":
+    if larr[0] == "POLYGONS" or larr[0] == "CELLS":
         tnum = int(larr[1])
         ttnum = int(larr[2])
         npt = float(ttnum) / tnum
@@ -149,7 +149,7 @@ def import_vtk(infile):
             return
         t = np.delete(t, 0, 1)
     else:
-        print("[read: " + line + " expected POLYGONS] --> FAILED\n")
+        print("[read: " + line + " expected POLYGONS or CELLS] --> FAILED\n")
         return
     f.close()
     print(" --> DONE ( V: " + str(v.shape[0]) + " , T: " + str(t.shape[0]) + " )\n")

--- a/lapy/TriaIO.py
+++ b/lapy/TriaIO.py
@@ -24,7 +24,7 @@ def import_fssurf(infile):
         print("[file not found or not readable]\n")
         return
     return TriaMesh(surf[0],surf[1],fsinfo=surf[2])
-    
+
 
 def import_off(infile):
     """
@@ -100,14 +100,14 @@ def import_vtk(infile):
         return
     # expect Dataset Polydata line after ASCII:
     line = f.readline()
-    if not line.startswith("DATASET POLYDATA"):
-        print("[read: " + line + " expected DATASET POLYDATA] --> FAILED\n")
+    if not line.startswith("DATASET POLYDATA") and not line.startswith("DATASET UNSTRUCTURED_GRID"):
+        print("[read: " + line + " expected DATASET POLYDATA or DATASET UNSTRUCTURED_GRID] --> FAILED\n")
         return
     # read number of points
     line = f.readline()
     larr = line.split()
-    if larr[0] != "POINTS" or larr[2] != "float":
-        print("[read: " + line + " expected POINTS # float] --> FAILED\n")
+    if larr[0] != "POINTS" or (larr[2] != "float" and larr[2] != "double"):
+        print("[read: " + line + " expected POINTS # float or POINTS # double ] --> FAILED\n")
         return
     pnum = int(larr[1])
     # read points as chunk
@@ -116,7 +116,7 @@ def import_vtk(infile):
     # expect polygon or tria_strip line
     line = f.readline()
     larr = line.split()
-    if larr[0] == "POLYGONS":
+    if larr[0] == "POLYGONS" or larr[0] == "CELLS":
         tnum = int(larr[1])
         ttnum = int(larr[2])
         npt = float(ttnum) / tnum
@@ -440,7 +440,7 @@ def export_vtk(tria, outfile):
         f.write('\n')
     f.close()
 
-    
+
 def export_fssurf(tria, outfile):
     """
     Save Freesurfer Surface Geometry file (wrap Nibabel)
@@ -452,5 +452,3 @@ def export_fssurf(tria, outfile):
     except IOError:
         print("[File " + outfile + " not writable]")
         return
-
-    


### PR DESCRIPTION
This is a redesign and rewrite of the ShapeDNA module; all external (FreeSurfer) commands have been moved to the BrainPrint-Python scripts, and post-processing (normaliziation, reweighting, asymmetry) has been moved from the BrainPrint-Python module to this module. Beyond that, the code has been streamlined and simplified. Usage has changed as well. Results are consistent with previous version. I suggest giving a new tag to this version (maybe 0.11), because there are some major changes, and because the corresponding changes in the BrainPrint-Python will specifically require this particular LaPy version.