### PR TITLE
Format Solver.py docstring to match numpy convention

### DIFF
--- a/lapy/Conformal.py
+++ b/lapy/Conformal.py
@@ -72,14 +72,12 @@ def spherical_conformal_map(tria):
         + sparse.csc_matrix(((1, 1, 1), (fixed, fixed)), shape=(nv, nv))
     )
 
-    # find embedding of the bigtria (bounary condition later)
+    # find embedding of the bigtria (boundary condition later)
     # arbitrarily set first two points
     x0, y0, x1, y1 = 0, 0, 1, 0
     a = tria.v[p1, :] - tria.v[p0, :]
     b = tria.v[p2, :] - tria.v[p0, :]
-    sin1 = np.linalg.norm(np.cross(a, b)) / (
-        np.linalg.norm(a) * np.linalg.norm(b)
-    )
+    sin1 = np.linalg.norm(np.cross(a, b)) / (np.linalg.norm(a) * np.linalg.norm(b))
     ori_h = np.linalg.norm(b) * sin1
     ratio = np.sqrt(((x0 - x1) ** 2 + (y0 - y1) ** 2)) / np.linalg.norm(a)
     y2 = ori_h * ratio  # compute the coordinates of the third vertex
@@ -109,9 +107,7 @@ def spherical_conformal_map(tria):
 
     # find the index of the southernmost triangle
     index = np.argsort(
-        np.abs(z[tria.t[:, 0]])
-        + np.abs(z[tria.t[:, 1]])
-        + np.abs(z[tria.t[:, 2]])
+        np.abs(z[tria.t[:, 0]]) + np.abs(z[tria.t[:, 1]]) + np.abs(z[tria.t[:, 2]])
     )
     inner = index[0]
     if inner == bigtri:
@@ -362,30 +358,19 @@ def linear_beltrami_solver(tria, mu, landmark, target):
     v11 = (af * uxv1 * uxv1 + 2 * bf * uxv1 * uyv1 + gf * uyv1 * uyv1) / area2
     v22 = (af * uxv2 * uxv2 + 2 * bf * uxv2 * uyv2 + gf * uyv2 * uyv2) / area2
     v01 = (
-        af * uxv1 * uxv0
-        + bf * uxv1 * uyv0
-        + bf * uxv0 * uyv1
-        + gf * uyv1 * uyv0
+        af * uxv1 * uxv0 + bf * uxv1 * uyv0 + bf * uxv0 * uyv1 + gf * uyv1 * uyv0
     ) / area2
     v12 = (
-        af * uxv2 * uxv1
-        + bf * uxv2 * uyv1
-        + bf * uxv1 * uyv2
-        + gf * uyv2 * uyv1
+        af * uxv2 * uxv1 + bf * uxv2 * uyv1 + bf * uxv1 * uyv2 + gf * uyv2 * uyv1
     ) / area2
     v20 = (
-        af * uxv0 * uxv2
-        + bf * uxv0 * uyv2
-        + bf * uxv2 * uyv0
-        + gf * uyv0 * uyv2
+        af * uxv0 * uxv2 + bf * uxv0 * uyv2 + bf * uxv2 * uyv0 + gf * uyv0 * uyv2
     ) / area2
 
     # create symmetric A
     i = np.column_stack((t0, t1, t2, t0, t1, t1, t2, t2, t0)).reshape(-1)
     j = np.column_stack((t0, t1, t2, t1, t0, t2, t1, t0, t2)).reshape(-1)
-    dat = np.column_stack(
-        (v00, v11, v22, v01, v01, v12, v12, v20, v20)
-    ).reshape(-1)
+    dat = np.column_stack((v00, v11, v22, v01, v01, v12, v12, v20, v20)).reshape(-1)
     nv = tria.v.shape[0]
     A = sparse.csc_matrix((dat, (i, j)), shape=(nv, nv), dtype=complex)
 

--- a/lapy/Conformal.py
+++ b/lapy/Conformal.py
@@ -18,6 +18,7 @@ from scipy.optimize import minimize
 
 from .Solver import Solver
 from .TriaMesh import TriaMesh
+from .utils._imports import import_optional_dependency
 
 
 def spherical_conformal_map(tria):
@@ -413,18 +414,14 @@ def linear_beltrami_solver(tria, mu, landmark, target):
 
 
 def sparse_symmetric_solve(A, b, use_cholmod=True):
-    from scipy.sparse.linalg import splu
-
-    if use_cholmod:
-        try:
-            from sksparse.cholmod import cholesky
-        except ImportError:
-            use_cholmod = False
-    if use_cholmod:
+    sksparse = import_optional_dependency("sksparse", raise_error=use_cholmod)
+    if sksparse is not None:
         print("Solver: Cholesky decomposition from scikit-sparse cholmod ...")
-        chol = cholesky(A)
+        chol = sksparse.cholmod.cholesky(A)
         x = chol(b)
     else:
+        from scipy.sparse.linalg import splu
+
         print("Solver: spsolve (LU decomposition) ...")
         lu = splu(A)
         x = lu.solve(b)

--- a/lapy/DiffGeo.py
+++ b/lapy/DiffGeo.py
@@ -28,9 +28,7 @@ def compute_rotated_f(geom, vfunc):
     if type(geom).__name__ == "TriaMesh":
         return tria_compute_rotated_f(geom, vfunc)
     else:
-        raise ValueError(
-            'Geometry type "' + type(geom).__name__ + '" not implemented'
-        )
+        raise ValueError('Geometry type "' + type(geom).__name__ + '" not implemented')
 
 
 def compute_geodesic_f(geom, vfunc):
@@ -178,9 +176,7 @@ def tria_compute_divergence(tria, tfunc):
     dat = np.column_stack((x0, x1, x2)).reshape(-1)
     # convert back to nparray 1D
     vfunc = np.squeeze(
-        np.asarray(
-            0.5 * sparse.csc_matrix((dat, (i, j))).todense(), dtype=tfunc.dtype
-        )
+        np.asarray(0.5 * sparse.csc_matrix((dat, (i, j))).todense(), dtype=tfunc.dtype)
     )
     return vfunc
 
@@ -227,9 +223,7 @@ def tria_compute_divergence2(tria, tfunc):
     i = np.column_stack((tria.t[:, 0], tria.t[:, 1], tria.t[:, 2])).reshape(-1)
     j = np.zeros((3 * len(tria.t), 1), dtype=int).reshape(-1)
     dat = np.column_stack((x0, x1, x2)).reshape(-1)
-    vfunc = np.squeeze(
-        np.asarray(0.5 * sparse.csc_matrix((dat, (i, j))).todense())
-    )
+    vfunc = np.squeeze(np.asarray(0.5 * sparse.csc_matrix((dat, (i, j))).todense()))
     return vfunc
 
 
@@ -474,9 +468,7 @@ def tria_spherical_project(tria, flow_iter=3, debug=False):
     # do a few mean curvature flow euler steps to make more convex
     # three should be sufficient
     if flow_iter > 0:
-        tflow = tria_mean_curvature_flow(
-            TriaMesh(vn, tria.t), max_iter=flow_iter
-        )
+        tflow = tria_mean_curvature_flow(TriaMesh(vn, tria.t), max_iter=flow_iter)
         vn = tflow.v
 
     # project to sphere and scaled to have the same scale/origin as FS:
@@ -558,15 +550,15 @@ def tet_compute_gradient(tet, vfunc):
     voli = np.divide(1.0, vol)[:, np.newaxis]
     # sum weighted edges
     # c0 = vfunc[t[:,0],np.newaxis] * np.cross(,)
-    c1 = (
-        vfunc[tet.t[:, 1], np.newaxis] - vfunc[tet.t[:, 0], np.newaxis]
-    ) * np.cross(e2, e5)
-    c2 = (
-        vfunc[tet.t[:, 2], np.newaxis] - vfunc[tet.t[:, 0], np.newaxis]
-    ) * np.cross(e3, e4)
-    c3 = (
-        vfunc[tet.t[:, 3], np.newaxis] - vfunc[tet.t[:, 0], np.newaxis]
-    ) * np.cross(-e2, e0)
+    c1 = (vfunc[tet.t[:, 1], np.newaxis] - vfunc[tet.t[:, 0], np.newaxis]) * np.cross(
+        e2, e5
+    )
+    c2 = (vfunc[tet.t[:, 2], np.newaxis] - vfunc[tet.t[:, 0], np.newaxis]) * np.cross(
+        e3, e4
+    )
+    c3 = (vfunc[tet.t[:, 3], np.newaxis] - vfunc[tet.t[:, 0], np.newaxis]) * np.cross(
+        -e2, e0
+    )
     # divided by parallelepiped vol
     tfunc = voli * (c1 + c2 + c3)
     return tfunc
@@ -607,9 +599,9 @@ def tet_compute_divergence(tet, tfunc):
     x1 = (n1 * tfunc).sum(1)
     x2 = (n2 * tfunc).sum(1)
     x3 = (n3 * tfunc).sum(1)
-    i = np.column_stack(
-        (tet.t[:, 0], tet.t[:, 1], tet.t[:, 2], tet.t[:, 3])
-    ).reshape(-1)
+    i = np.column_stack((tet.t[:, 0], tet.t[:, 1], tet.t[:, 2], tet.t[:, 3])).reshape(
+        -1
+    )
     j = np.zeros((4 * len(tet.t), 1), dtype=int).reshape(-1)
     dat = np.column_stack((x0, x1, x2, x3)).reshape(-1)
     vfunc = -np.squeeze(

--- a/lapy/FuncIO.py
+++ b/lapy/FuncIO.py
@@ -134,18 +134,14 @@ def import_ev(infile):
             i = i + 1
         elif ll[i].lstrip().startswith("Eigenvalues"):
             i = i + 1
-            while (
-                ll[i].find("{") < 0
-            ):  # possibly introduce termination criterion
+            while ll[i].find("{") < 0:  # possibly introduce termination criterion
                 i = i + 1
             if ll[i].find("}") >= 0:  # '{' and '}' on the same line
                 evals = ll[i].strip().replace("{", "").replace("}", "")
             else:
                 evals = str()
                 while ll[i].find("}") < 0:
-                    evals = evals + ll[i].strip().replace("{", "").replace(
-                        "}", ""
-                    )
+                    evals = evals + ll[i].strip().replace("{", "").replace("}", "")
                     i = i + 1
                 evals = evals + ll[i].strip().replace("{", "").replace("}", "")
             evals = np.array(evals.split(";")).astype(np.float)
@@ -156,16 +152,10 @@ def import_ev(infile):
             while not (ll[i].strip().startswith("sizes")):
                 i = i + 1
             d.update(
-                {
-                    "EigenvectorsSize": np.array(
-                        ll[i].strip().split()[1:]
-                    ).astype(np.int)
-                }
+                {"EigenvectorsSize": np.array(ll[i].strip().split()[1:]).astype(np.int)}
             )
             i = i + 1
-            while (
-                ll[i].find("{") < 0
-            ):  # possibly introduce termination criterion
+            while ll[i].find("{") < 0:  # possibly introduce termination criterion
                 i = i + 1
             if ll[i].find("}") >= 0:  # '{' and '}' on the same line
                 evecs = ll[i].strip().replace("{", "").replace("}", "")
@@ -176,18 +166,14 @@ def import_ev(infile):
                         "}", ""
                     ).replace("(", "").replace(")", "")
                     i = i + 1
-                evecs = evecs + ll[i].strip().replace("{", "").replace(
-                    "}", ""
-                ).replace("(", "").replace(")", "")
+                evecs = evecs + ll[i].strip().replace("{", "").replace("}", "").replace(
+                    "(", ""
+                ).replace(")", "")
             evecs = np.array(
                 evecs.replace(";", " ").replace(",", " ").strip().split()
             ).astype(np.float)
-            if len(evecs) == (
-                d["EigenvectorsSize"][0] * d["EigenvectorsSize"][1]
-            ):
-                evecs = np.transpose(
-                    np.reshape(evecs, d["EigenvectorsSize"][1::-1])
-                )
+            if len(evecs) == (d["EigenvectorsSize"][0] * d["EigenvectorsSize"][1]):
+                evecs = np.transpose(np.reshape(evecs, d["EigenvectorsSize"][1::-1]))
                 d.update({"Eigenvectors": evecs})
             else:
                 print(

--- a/lapy/Heat.py
+++ b/lapy/Heat.py
@@ -19,9 +19,7 @@ def diagonal(t, x, evecs, evals, n):
 
     """
     # maybe add code to check dimensions of input and flip axis if necessary
-    h = np.matmul(
-        evecs[x, 0:n] * evecs[x, 0:n], np.exp(-np.matmul(evals[0:n], t))
-    )
+    h = np.matmul(evecs[x, 0:n] * evecs[x, 0:n], np.exp(-np.matmul(evals[0:n], t)))
     return h
 
 
@@ -45,9 +43,7 @@ def kernel(t, vfix, evecs, evals, n):
 
     """
     # h = evecs * ( exp(-evals * t) .* repmat(evecs(vfix,:)',1,length(t))  )
-    h = np.matmul(
-        evecs[:, 0:n], (np.exp(np.matmul(-evals[0:n], t)) * evecs[vfix, 0:n])
-    )
+    h = np.matmul(evecs[:, 0:n], (np.exp(np.matmul(-evals[0:n], t)) * evecs[vfix, 0:n]))
     return h
 
 

--- a/lapy/Plot.py
+++ b/lapy/Plot.py
@@ -370,9 +370,7 @@ def plot_tria_mesh(
             #    max_fcol = 1
             # colormap = cm.RdBu
             colormap = _get_colorscale(min_fcol, max_fcol)
-            facecolor = [
-                _map_z2color(zz, colormap, min_fcol, max_fcol) for zz in tfunc
-            ]
+            facecolor = [_map_z2color(zz, colormap, min_fcol, max_fcol) for zz in tfunc]
             # for tria colors overwrite flatshading to be true:
             triangles = go.Mesh3d(
                 x=x,
@@ -420,9 +418,7 @@ def plot_tria_mesh(
                 mode="lines",
                 line=dict(color=tic_color, width=2),
             )
-            triangles = go.Mesh3d(
-                x=x, y=y, z=z, i=i, j=j, k=k, flatshading=flatshading
-            )
+            triangles = go.Mesh3d(x=x, y=y, z=z, i=i, j=j, k=k, flatshading=flatshading)
         else:
             raise ValueError(
                 "tfunc should be scalar (face color) or 3d for each triangle"
@@ -473,9 +469,7 @@ def plot_tria_mesh(
         vlines = go.Scatter3d(
             x=xv, y=yv, z=zv, mode="lines", line=dict(color=tic_color, width=2)
         )
-        triangles = go.Mesh3d(
-            x=x, y=y, z=z, i=i, j=j, k=k, flatshading=flatshading
-        )
+        triangles = go.Mesh3d(x=x, y=y, z=z, i=i, j=j, k=k, flatshading=flatshading)
     else:
         raise ValueError("vfunc should be scalar or 3d for each vertex")
 

--- a/lapy/Solver.py
+++ b/lapy/Solver.py
@@ -80,9 +80,7 @@ class Solver:
             print("TetMesh with regular Laplace")
             a, b = self._fem_tetra(geometry, lump)
         else:
-            raise ValueError(
-                'Geometry type "' + type(geometry).__name__ + '" unknown'
-            )
+            raise ValueError('Geometry type "' + type(geometry).__name__ + '" unknown')
         self.stiffness = a
         self.mass = b
         self.geotype = type(geometry)
@@ -172,7 +170,9 @@ class Solver:
         return a, b
 
     @staticmethod
-    def _fem_tria_aniso(tria, u1, u2, aniso_mat, lump: bool = False):  # computeABtria(v,t)
+    def _fem_tria_aniso(
+        tria, u1, u2, aniso_mat, lump: bool = False
+    ):  # computeABtria(v,t)
         r"""Compute the 2 sparse symmetric matices of the Laplace-Beltrami operator for a triangle mesh.
 
         The 2 sparse symmetric matrices are computed for a given triangle mesh using the
@@ -325,12 +325,8 @@ class Solver:
                 (b_ij, b_ij, b_ij, b_ij, b_ij, b_ij, b_ii, b_ii, b_ii)
             ).reshape(-1)
             # stack edge and diag coords for matrix indices
-            i = np.column_stack((t1, t2, t2, t3, t3, t1, t1, t2, t3)).reshape(
-                -1
-            )
-            j = np.column_stack((t2, t1, t3, t2, t1, t3, t1, t2, t3)).reshape(
-                -1
-            )
+            i = np.column_stack((t1, t2, t2, t3, t3, t1, t1, t2, t3)).reshape(-1)
+            j = np.column_stack((t2, t1, t3, t2, t1, t3, t1, t2, t3)).reshape(-1)
             # Construct sparse matrix:
             b = sparse.csc_matrix((local_b, (i, j)))
         else:
@@ -409,9 +405,9 @@ class Solver:
         e36 = np.sum(e3 * e6, axis=1)
         # compute entries for A (negations occur when one edge direction is flipped)
         # these can be computed multiple ways
-        # basically for ij, take opposing edge (call it Ek) and two edges from the starting
-        # point of Ek to point i (=El) and to point j (=Em), then these are of the
-        # scheme:   (El * Ek)  (Em * Ek) - (El * Em) (Ek * Ek)
+        # basically for ij, take opposing edge (call it Ek) and two edges from the
+        # starting point of Ek to point i (=El) and to point j (=Em), then these are of
+        # the scheme:   (El * Ek)  (Em * Ek) - (El * Em) (Ek * Ek)
         # where * is vector dot product
         a12 = (-e36 * e26 + e23 * e66) / vol
         a13 = (-e15 * e25 + e12 * e55) / vol
@@ -523,7 +519,8 @@ class Solver:
         #                          clockwise when looking from above
         #
         # Outputs:  A - sparse sym. (n x n) positive semi definite numpy matrix
-        #           B - sparse sym. (n x n) positive definite numpy matrix (inner product)
+        #           B - sparse sym. (n x n) positive definite numpy matrix (inner
+        #               product)
         tnum = vox.t.shape[0]
         # Linear local matrices on unit voxel
         tb = (
@@ -600,17 +597,11 @@ class Solver:
         else:
             local_b = tb * vol
         local_a = vol * (a0 * ta00 + a1 * ta11 + a2 * ta22)
-        local_b = np.repeat(local_b[np.newaxis, :, :], tnum, axis=0).reshape(
-            -1
-        )
-        local_a = np.repeat(local_a[np.newaxis, :, :], tnum, axis=0).reshape(
-            -1
-        )
+        local_b = np.repeat(local_b[np.newaxis, :, :], tnum, axis=0).reshape(-1)
+        local_a = np.repeat(local_a[np.newaxis, :, :], tnum, axis=0).reshape(-1)
         # Construct row and col indices.
         i = np.array([np.tile(x, (8, 1)) for x in vox.t]).reshape(-1)
-        j = np.array(
-            [np.transpose(np.tile(x, (8, 1))) for x in vox.t]
-        ).reshape(-1)
+        j = np.array([np.transpose(np.tile(x, (8, 1))) for x in vox.t]).reshape(-1)
         # Construct sparse matrix:
         a = sparse.csc_matrix((local_a, (i, j)))
         b = sparse.csc_matrix((local_b, (i, j)))
@@ -638,9 +629,7 @@ class Solver:
 
         sigma = -0.01
         if self.sksparse is not None:
-            print(
-                "Solver: Cholesky decomposition from scikit-sparse cholmod ..."
-            )
+            print("Solver: Cholesky decomposition from scikit-sparse cholmod ...")
             chol = self.sksparse.cholmod.cholesky(self.stiffness - sigma * self.mass)
             op_inv = LinearOperator(
                 matvec=chol,
@@ -667,8 +656,8 @@ class Solver:
         """Solver for the poisson equation with boundary conditions.
 
         This solver is based on the ``A`` and ``B`` Laplace matrices where ``A x = B h``
-        and ``A`` is a sparse symetric positive semi definitive matrix of shape
-        ``(n`, n)`` and B is a sparse symetric positive definitive matrix of shape
+        and ``A`` is a sparse symmetric positive semi definitive matrix of shape
+        ``(n`, n)`` and B is a sparse symmetric positive definitive matrix of shape
         ``(n, n)``.
 
         Parameters
@@ -697,12 +686,10 @@ class Solver:
         """
         # check matrices
         dim = self.stiffness.shape[0]
-        if (
-            self.stiffness.shape != self.mass.shape
-            or self.stiffness.shape[1] != dim
-        ):
+        if self.stiffness.shape != self.mass.shape or self.stiffness.shape[1] != dim:
             raise ValueError(
-                "Error: Square input matrices should have same number of rows and columns"
+                "Error: Square input matrices should have same number of rows and "
+                "columns."
             )
         # create vector h
         if np.isscalar(h):
@@ -770,9 +757,7 @@ class Solver:
         # solve A x = b
         print("Matrix Format now: " + a.getformat())
         if self.sparse is not None:
-            print(
-                "Solver: Cholesky decomposition from scikit-sparse cholmod ..."
-            )
+            print("Solver: Cholesky decomposition from scikit-sparse cholmod ...")
             chol = self.sparse.cholesky(a)
             x = chol(b)
         else:

--- a/lapy/Solver.py
+++ b/lapy/Solver.py
@@ -641,7 +641,7 @@ class Solver:
             print(
                 "Solver: Cholesky decomposition from scikit-sparse cholmod ..."
             )
-            chol = self.sksparse.cholesky(self.stiffness - sigma * self.mass)
+            chol = self.sksparse.cholmod.cholesky(self.stiffness - sigma * self.mass)
             op_inv = LinearOperator(
                 matvec=chol,
                 shape=self.stiffness.shape,

--- a/lapy/Solver.py
+++ b/lapy/Solver.py
@@ -1,49 +1,58 @@
+import sys
+from typing import Optional, Tuple, Union
+
 import numpy as np
 from scipy import sparse
 
+from .TetMesh import TetMesh
+from .TriaMesh import TriaMesh
+from .utils._imports import import_optional_dependency
+
 
 class Solver:
-    """A class representing a linear FEM solver for:
-    Laplace Eigenvalue problems and Poisson Equation
+    """A linear FEM solver for Laplace Eigenvalue problems and Poisson Equation.
 
     Inputs can be geometry classes which have vertices and elements.
-    Currently TriaMesh and TetMesh are implemented.
+    Currently `~lapy.TriaMesh` and `~lapy.TetMesh` are implemented.
     FEM matrices (stiffness (or A) and mass matrix (or B)) are computed
-    during the construction. After that the Eigenvalue solver (eigs) or
-    Poisson Solver (poisson) can be called.
+    during the construction. After that the Eigenvalue solver (`lapy.Solver.eigs`) or
+    Poisson Solver (`lapy.Solver.poisson`) can be called.
 
-    The class has a static member to create the mass matrix of TriaMesh
-    for external function that do not need stiffness.
+    Parameters
+    ----------
+    geometry : TriaMesh | TetMesh
+        Mesh geometry.
+    lump : bool
+        If True, lump the mass matrix (diagonal).
+    aniso : float | tuple of shape (2,)
+        Anisotropy for curvature based anisotopic Laplace.
+        If a tuple ``(a_min, a_max), differentially affects the minimum and maximum
+        curvature directions. e.g. ``(0, 50)`` will set scaling to 1 into the minimum
+        curvature direction, even if the maximum curvature is large in those regions (
+        i.e. isotropic in regions with large maximum curvature and minimum curvature
+        close to 0, i.e. a concave cylinder).
+    aniso_smooth : int
+        Number of smoothing iterations for curvature computation on vertices.
+    use_cholmod : bool
+        If True, attempts to use the Cholesky decomposition for improved execution
+        speed. Requires the ``scikit-sparse`` library. If it can not be found, fallback
+        to LU decomposition.
+
+    Notes
+    -----
+    The class has a static member to create the mass matrix of `~lapy.TriaMesh` for
+    external function that do not need stiffness.
     """
 
     def __init__(
         self,
-        geometry,
-        lump=False,
-        aniso=None,
-        aniso_smooth=10,
-        use_cholmod=True,
-    ):
-        """
-        Construct the Solver class. Computes linear Laplace FEM stiffness and
-        mass matrix for TriaMesh or TetMesh input geometries. For TriaMesh it can also
-        construct the anisotropic Laplace.
-
-        Inputs:
-            geometry    : is a geometry class, currently either TriaMesh or TetMesh
-            aniso       : float, anisotropy for curvature based anisotopic Laplace
-                          can also be tuple (a_min, a_max) to differentially affect
-                          the min and max curvature directions. E.g. (0,50) will set
-                          scaling to 1 into min curv direction even if the max curvature
-                          is large in those regions (= isotropic in regions with
-                          large max curv and min curv close to zero= concave cylinder)
-            lump        : whether to lump the mass matrix (diagonal), default False
-            use_cholmod : try to use the Cholesky decomposition from the cholmod
-                          library for improved speed. This requires skikit sparse to
-                          be installed. If it cannot be found, we fallback to LU
-                          decomposition.
-        """
-        self.use_cholmod = use_cholmod
+        geometry: Union[TriaMesh, TetMesh],
+        lump: bool = False,
+        aniso: Optional[Union[float, Tuple[float, float]]] = None,
+        aniso_smooth: int = 10,
+        use_cholmod: bool = True,
+    ) -> None:
+        self.sksparse = import_optional_dependency("sksparse", raise_error=use_cholmod)
         if type(geometry).__name__ == "TriaMesh":
             if aniso is not None:
                 # anisotropic Laplace
@@ -79,24 +88,35 @@ class Solver:
         self.geotype = type(geometry)
 
     @staticmethod
-    def _fem_tria(tria, lump=False):
-        """
-        computeABtria(v,t) computes the two sparse symmetric matrices representing
-               the Laplace Beltrami Operator for a given triangle mesh using
-               the linear finite element method (assuming a closed mesh or
-               the Neumann boundary condition).
+    def _fem_tria(tria: TriaMesh, lump: bool = False):  # computeABtria(v,t)
+        r"""Compute the 2 sparse symmetric matices of the Laplace-Beltrami operator for a triangle mesh.
 
-        Inputs:   v - vertices : list of lists of 3 floats
-                  t - triangles: list of lists of 3 int of indices (>=0) into v array
+        The 2 sparse symmetric matrices are computed for a given triangle mesh using the
+        linear finite element method (assuming a closed mesh or Neumann boundary
+        condition).
 
-        Outputs:  A - sparse sym. (n x n) positive semi definite numpy matrix
-                  B - sparse sym. (n x n) positive definite numpy matrix (inner product)
+        Parameters
+        ----------
+        tria : TriaMesh
+            Triangle mesh.
+        lump : bool
+            If True, ``B`` should be lumped (diagonal).
 
-        Can be used to solve sparse generalized Eigenvalue problem: A x = lambda B x
-        or to solve Poisson equation: A x = B f (where f is function on mesh vertices)
-        or to solve Laplace equation: A x = 0
-        or to model the operator's action on a vector x:   y = B\(Ax)
-        """
+        Returns
+        -------
+        A : csc_matrix of shape (n, n)
+            Sparse symmetric positive semi definite matrix.
+        B : csc_matrix of shape (n, n)
+            Sparse symmetric positive definite matrix.
+
+        Notes
+        -----
+        This static method can be used to solve:
+        * sparse generalized Eigenvalue problem: ``A x = lambda B x``
+        * Poisson equation: ``A x = B f`` (where f is function on mesh vertices)
+        * Laplace equation: ``A x = 0``
+        or to model the operator's action on a vector ``x``: ``y = B\(Ax)``.
+        """  # noqa: E501
         import sys
 
         # Compute vertex coordinates and a difference vector for each triangle:
@@ -152,30 +172,43 @@ class Solver:
         return a, b
 
     @staticmethod
-    def _fem_tria_aniso(tria, u1, u2, aniso_mat, lump=False):
-        """
-        computeABtria(v,t) computes the two sparse symmetric matrices representing
-               the Laplace Beltrami Operator for a given triangle mesh using
-               the linear finite element method (assuming a closed mesh or
-               the Neumann boundary condition).
+    def _fem_tria_aniso(tria, u1, u2, aniso_mat, lump: bool = False):  # computeABtria(v,t)
+        r"""Compute the 2 sparse symmetric matices of the Laplace-Beltrami operator for a triangle mesh.
 
-        Inputs:   v  - vertices : list of lists of 3 floats
-                  t  - triangles: N list of lists of 3 int of indices (>=0) into v array
-                  u1 - min curv:  min curvature direction per triangle (Nx3 floats)
-                  u2 - max curv:  max curvature direction per triangle (Nx3 floats)
-                  aniso_mat  - anisotropy matrix: diagonal elements in u1,u2 basis per
-                                  triangle (Nx2 floats)
+        The 2 sparse symmetric matrices are computed for a given triangle mesh using the
+        linear finite element method (assuming a closed mesh or Neumann boundary
+        condition).
 
-        Outputs:  A  - sparse sym. (n x n) positive semi definite numpy matrix
-                  B  - sparse sym. (n x n) positive definite numpy matrix (inner product)
+        Parameters
+        ----------
+        tria : TriaMesh
+            Triangle mesh.
+        u1 : array
+            Minimum curvature direction per triangle ((N, 3) floats).
+        u2 : array
+            Maximum curvature direction per triangle ((N, 3) floats).
+        aniso_mat : array
+            Anisotropy matrix. Diagonal elements in ``u1``, ``u2`` basis per triangle
+            ((N, 2) floats).
+        lump : bool
+            If True, ``B`` should be lumped (diagonal).
 
-        Can be used to solve sparse generalized Eigenvalue problem: A x = lambda B x
-        or to solve Poisson equation: A x = B f (where f is function on mesh vertices)
-        or to solve Laplace equation: A x = 0
-        or to model the operator's action on a vector x:   y = B\(Ax)
-        """
-        import sys
 
+        Returns
+        -------
+        A : csc_matrix of shape (n, n)
+            Sparse symmetric positive semi definite matrix.
+        B : csc_matrix of shape (n, n)
+            Sparse symmetric positive definite matrix.
+
+        Notes
+        -----
+        This static method can be used to solve:
+        * sparse generalized Eigenvalue problem: ``A x = lambda B x``
+        * Poisson equation: ``A x = B f`` (where f is function on mesh vertices)
+        * Laplace equation: ``A x = 0``
+        or to model the operator's action on a vector ``x``: ``y = B\(Ax)``.
+        """  # noqa: E501
         # Compute vertex coordinates and a difference vector for each triangle:
         t1 = tria.t[:, 0]
         t2 = tria.t[:, 1]
@@ -240,24 +273,33 @@ class Solver:
         return a, b
 
     @staticmethod
-    def fem_tria_mass(tria, lump=False):
-        """
-        Computes the sparse symmetric mass matrix of the
-        Laplace Beltrami Operator for a given triangle mesh using the
-        linear finite element method (assuming a closed mesh or the
-        Neumann boundary condition).
-        This is here, because sometimes only a mass matrix is needed and then
-        this call is faster than the constructor above.
+    def fem_tria_mass(tria: TriaMesh, lump: bool = False):
+        """Compute the sparse symmetric mass matrix of the Laplace-Beltrami operator for a given triangle mesh.
 
-        Inputs:   v - vertices : list of lists of 3 floats
-                  t - triangles: list of lists of 3 int of indices (>=0) into v array
-                  lump         : Bool if B matrix should be lumped (diagnoal), default False
+        The sparse symmetric matrix is computed for a given triangle mesh using the
+        linear finite element method (assuming a closed mesh or Neumann boundary
+        condition).
+        This function is faster than the constructor above and can be used when only a
+        mass matrix is needed.
 
-        Outputs:  B - sparse sym. (n x n) positive definite numpy matrix (inner product)
+        Parameters
+        ----------
+        tria : TriaMesh
+            Triangle mesh.
+        lump : bool
+            If True, ``B`` should be lumped (diagonal).
 
-        This is only the mass matrix B of the Eigenvalue problem: A x = lambda B x
-        Area of the surface mesh can be obtained via B.sum()
-        """
+        Returns
+        -------
+        B : csc_matrix of shape (n, n)
+            Sparse symmetric positive definite matrix.
+
+        Notes
+        -----
+        This only returns the mass matrix ``B`` of the Eigenvalue problem:
+        ``A x = lambda B x``. The area of the surface mesh can be obtained via
+        ``B.sum()``.
+        """  # noqa: E501
         # Compute vertex coordinates and a difference vector for each triangle:
         t1 = tria.t[:, 0]
         t2 = tria.t[:, 1]
@@ -300,27 +342,34 @@ class Solver:
         return b
 
     @staticmethod
-    def _fem_tetra(tetra, lump=False):
-        """
-        computeABtetra(v,t) computes the two sparse symmetric matrices representing
-               the Laplace Beltrami Operator for a given tetrahedral mesh using
-               the linear finite element method (Neumann boundary condition).
+    def _fem_tetra(tetra: TetMesh, lump: bool = False):
+        r"""Compute the 2 sparse symmetric matices of the Laplace-Beltrami operator for a tetrahedral mesh.
 
-        Inputs:   v - vertices : list of lists of 3 floats
-                  t - tetras   : list of lists of 4 int of indices (>=0) into v array
-                                 Ordering is important: first three vertices for
-                                 triangle counter-clockwise when looking at it from
-                                 the inside of the tetrahedron
-                  lump         : Bool if B matrix should be lumped (diagnoal), default False
+        The 2 sparse symmetric matrices are computed for a given tetrahedral mesh using
+        the linear finite element method (Neumann boundary condition).
 
-        Outputs:  A - sparse sym. (n x n) positive semi definite numpy matrix
-                  B - sparse sym. (n x n) positive definite numpy matrix (inner product)
+        Parameters
+        ----------
+        tetra : TetMesh
+            Tetrahedral mesh.
+        lump : bool
+            If True, ``B`` should be lumped (diagonal).
 
-        Can be used to solve sparse generalized Eigenvalue problem: A x = lambda B x
-        or to solve Poisson equation: A x = B f (where f is function on mesh vertices)
-        or to solve Laplace equation: A x = 0
-        or to model the operator's action on a vector x:   y = B\(Ax)
-        """
+        Returns
+        -------
+        A : csc_matrix of shape (n, n)
+            Sparse symmetric positive semi definite matrix.
+        B : csc_matrix of shape (n, n)
+            Sparse symmetric positive definite matrix.
+
+        Notes
+        -----
+        This static method can be used to solve:
+        * sparse generalized Eigenvalue problem: ``A x = lambda B x``
+        * Poisson equation: ``A x = B f`` (where f is function on mesh vertices)
+        * Laplace equation: ``A x = 0``
+        or to model the operator's action on a vector ``x``: ``y = B\(Ax)``.
+        """  # noqa: E501
         # Compute vertex coordinates and a difference vector for each triangle:
         t1 = tetra.t[:, 0]
         t2 = tetra.t[:, 1]
@@ -440,26 +489,41 @@ class Solver:
         return a, b
 
     @staticmethod
-    def _fem_voxels(vox, lump=False):
-        """
-        computeABvoxels(v,t) computes the two sparse symmetric matrices representing
-               the Laplace Beltrami Operator for a given voxel mesh using
-               the linear finite element method (Neumann boundary condition).
+    def _fem_voxels(vox, lump: bool = False):  # computeABvoxels(v,t)
+        r"""Compute the 2 sparse symmetric matices of the Laplace-Beltrami operator for a voxel mesh.
 
-        Inputs:   v - vertices : list of lists of 3 floats
-                  t - voxels   : list of lists of 8 int of indices (>=0) into v array
-                                 Ordering: base counter-clockwise, then top counter-
-                                 clockwise when looking from above
-                  lump         : Bool if B matrix should be lumped (diagnoal), default False
+        The 2 sparse symmetric matrices are computed for a given voxel mesh using the
+        linear finite element method (Neumann boundary condition).
 
-        Outputs:  A - sparse sym. (n x n) positive semi definite numpy matrix
-                  B - sparse sym. (n x n) positive definite numpy matrix (inner product)
+        Parameters
+        ----------
+        vox : array
+            Voxel mesh.
+        lump : bool
+            If True, ``B`` should be lumped (diagonal).
 
-        Can be used to solve sparse generalized Eigenvalue problem: A x = lambda B x
-        or to solve Poisson equation: A x = B f (where f is function on mesh vertices)
-        or to solve Laplace equation: A x = 0
-        or to model the operator's action on a vector x:   y = B\(Ax)
-        """
+        Returns
+        -------
+        A : csc_matrix of shape (n, n)
+            Sparse symmetric positive semi definite matrix.
+        B : csc_matrix of shape (n, n)
+            Sparse symmetric positive definite matrix.
+
+        Notes
+        -----
+        This static method can be used to solve:
+        * sparse generalized Eigenvalue problem: ``A x = lambda B x``
+        * Poisson equation: ``A x = B f`` (where f is function on mesh vertices)
+        * Laplace equation: ``A x = 0``
+        or to model the operator's action on a vector ``x``: ``y = B\(Ax)``.
+        """  # noqa: E501
+        # Inputs:   v - vertices : list of lists of 3 floats
+        #           t - voxels   : list of lists of 8 int of indices (>=0) into v array
+        #                          Ordering: base counter-clockwise, then top counter-
+        #                          clockwise when looking from above
+        #
+        # Outputs:  A - sparse sym. (n x n) positive semi definite numpy matrix
+        #           B - sparse sym. (n x n) positive definite numpy matrix (inner product)
         tnum = vox.t.shape[0]
         # Linear local matrices on unit voxel
         tb = (
@@ -552,39 +616,42 @@ class Solver:
         b = sparse.csc_matrix((local_b, (i, j)))
         return a, b
 
-    def eigs(self, k=10):
+    def eigs(self, k: int = 10):
+        """Compute the linear finite-element method Laplace-Beltrami spectrum.
+
+        Parameters
+        ----------
+        k : int
+            The number of eigenvalues and eigenvectors desired. ``k`` must be smaller
+            than ``N``. It is not possible to compute all eigenvectors of a matrix.
+
+        Returns
+        -------
+        eigenvalues : array of shape (k)
+            Array of k eigenvalues. For closed meshes or Neumann boundary condition,
+            ``0`` will be the first eigenvalue (with constant eigenvector).
+        eigenvectors : array of shape (N, k)
+            Array representing the k eigenvectors. The column ``eigenvectors[:, i]`` is
+            the eigenvector corresponding to ``eigenvalues[i]``.
         """
-        Compute linear finite-element method Laplace-Beltrami spectrum
+        from scipy.sparse.linalg import LinearOperator
 
-        :return:    eigenvalues     array: k Laplace eigenvalues, sorted.
-                                    For closed meshes, or Neumann boundary condition
-                                    0 will be first eigenvalue (with constant eigenfunction)
-                    eigenfunctions  array: (N x k) with k eigenfunctions (in the columns)
-        """
-        from scipy.sparse.linalg import LinearOperator, eigsh, splu
-
-        if self.use_cholmod:
-            try:
-                from sksparse.cholmod import cholesky
-            except ImportError:
-                self.use_cholmod = False
-
-        if self.use_cholmod:
+        sigma = -0.01
+        if self.sksparse is not None:
             print(
                 "Solver: Cholesky decomposition from scikit-sparse cholmod ..."
             )
-        else:
-            print("Solver: spsolve (LU decomposition) ...")
-            # turns out it is much faster to use cholesky and pass operator
-        sigma = -0.01
-        if self.use_cholmod:
-            chol = cholesky(self.stiffness - sigma * self.mass)
+            chol = self.sksparse.cholesky(self.stiffness - sigma * self.mass)
             op_inv = LinearOperator(
                 matvec=chol,
                 shape=self.stiffness.shape,
                 dtype=self.stiffness.dtype,
             )
         else:
+            from scipy.sparse.linalg import eigsh, splu
+
+            print("Solver: spsolve (LU decomposition) ...")
+            # turns out it is much faster to use cholesky and pass operator
             lu = splu(self.stiffness - sigma * self.mass)
             op_inv = LinearOperator(
                 matvec=lu.solve,
@@ -596,33 +663,38 @@ class Solver:
         )
         return eigenvalues, eigenvectors
 
-    def poisson(self, h=0.0, dtup=(), ntup=()):
+    def poisson(self, h=0.0, dtup=(), ntup=()):  # poissonSolver
+        """Solver for the poisson equation with boundary conditions.
+
+        This solver is based on the ``A`` and ``B`` Laplace matrices where ``A x = B h``
+        and ``A`` is a sparse symetric positive semi definitive matrix of shape
+        ``(n`, n)`` and B is a sparse symetric positive definitive matrix of shape
+        ``(n, n)``.
+
+        Parameters
+        ----------
+        h : float | array
+            Right hand side, can be constant or array with vertex values.
+            The default ``0`` corresponds to Laplace equation ``A x = 0``.
+        dtup : tuple
+            Dirichlet boundary condition as a tuple containing the index and data arrays
+            of same length. The default, an empty tuple, corresponds to no Dirichlet
+            condition.
+        ntup : tuple
+            Neumann boundary condition as a tuple containing the index and data arrays
+            of same length. The default, an empty tuple, corresponds to Neumann on all
+            boundaries.
+
+        Returns
+        -------
+        x : array
+            Array with vertex value of the solution.
+
+        Notes
+        -----
+        ``A`` and ``B`` are obtained via ``computeAB`` for either triangle or tetraheral
+        mesh.
         """
-        poissonSolver solves the poisson equation with boundary conditions
-               based on the A and B Laplace matrices:  A x = B h
-
-        Inputs:   A - sparse sym. (n x n) positive semi definite numpy matrix
-                  B - sparse sym. (n x n) positive definite numpy matrix (inner product)
-                      A and B are obtained via computeAB for either triangle or tet mesh
-        Optional:
-                  h - right hand side, can be constant or array with vertex values
-                      Default: 0.0 (Laplace equation A x = 0)
-                  dtup - Dirichlet boundary condition as a tuple.
-                         Tuple contains index and data arrays of same length.
-                         Default: no Dirichlet condition
-                  ntup - Neumann boundary condition as a tuple.
-                         Tuple contains index and data arrays of same length.
-                         Default: Neumann on all boundaries
-
-        Outputs:  x - array with vertex values of solution
-        """
-        from scipy.sparse.linalg import splu
-
-        if self.use_cholmod:
-            try:
-                from sksparse.cholmod import cholesky
-            except ImportError:
-                self.use_cholmod = False
         # check matrices
         dim = self.stiffness.shape[0]
         if (
@@ -697,13 +769,15 @@ class Solver:
             a = self.stiffness
         # solve A x = b
         print("Matrix Format now: " + a.getformat())
-        if self.use_cholmod:
+        if self.sparse is not None:
             print(
                 "Solver: Cholesky decomposition from scikit-sparse cholmod ..."
             )
-            chol = cholesky(a)
+            chol = self.sparse.cholesky(a)
             x = chol(b)
         else:
+            from scipy.sparse.linalg import splu
+
             print("Solver: spsolve (LU decomposition) ...")
             lu = splu(a)
             x = lu.solve(b.astype(np.float32))

--- a/lapy/TetIO.py
+++ b/lapy/TetIO.py
@@ -62,7 +62,7 @@ def import_gmsh(infile):
         f.close()
         return
     pnum = int(f.readline())
-    # read (nodes X 4) matrix as chunck
+    # read (nodes X 4) matrix as chunk
     # drop first column
     v = np.fromfile(f, "float32", 4 * pnum, " ")
     v.shape = (pnum, 4)
@@ -98,13 +98,7 @@ def import_gmsh(infile):
         f.close()
         return
     f.close()
-    print(
-        " --> DONE ( V: "
-        + str(v.shape[0])
-        + " , T: "
-        + str(t.shape[0])
-        + " )\n"
-    )
+    print(" --> DONE ( V: " + str(v.shape[0]) + " , T: " + str(t.shape[0]) + " )\n")
     return TetMesh(v, t)
 
 
@@ -167,9 +161,7 @@ def import_vtk(infile):
         npt = float(ttnum) / tnum
         if npt != 5.0:
             print(
-                "[having: "
-                + str(npt)
-                + " data per tetra, expected 4+1] --> FAILED\n"
+                "[having: " + str(npt) + " data per tetra, expected 4+1] --> FAILED\n"
             )
             return
         t = np.fromfile(f, "int", ttnum, " ")
@@ -182,13 +174,7 @@ def import_vtk(infile):
         print("[read: " + line + " expected POLYGONS or CELLS] --> FAILED\n")
         return
     f.close()
-    print(
-        " --> DONE ( V: "
-        + str(v.shape[0])
-        + " , T: "
-        + str(t.shape[0])
-        + " )\n"
-    )
+    print(" --> DONE ( V: " + str(v.shape[0]) + " , T: " + str(t.shape[0]) + " )\n")
     return TetMesh(v, t)
 
 
@@ -215,11 +201,7 @@ def export_vtk(tet, outfile):
         f.write(" ".join(map(str, tet.v[i, :])))
         f.write("\n")
     f.write(
-        "POLYGONS "
-        + str(np.shape(tet.t)[0])
-        + " "
-        + str(5 * np.shape(tet.t)[0])
-        + "\n"
+        "POLYGONS " + str(np.shape(tet.t)[0]) + " " + str(5 * np.shape(tet.t)[0]) + "\n"
     )
     for i in range(np.shape(tet.t)[0]):
         f.write(" ".join(map(str, np.append(4, tet.t[i, :]))))

--- a/lapy/TetMesh.py
+++ b/lapy/TetMesh.py
@@ -46,12 +46,12 @@ class TetMesh:
         t2 = self.t[:, 1]
         t3 = self.t[:, 2]
         t4 = self.t[:, 3]
-        i = np.column_stack(
-            (t1, t2, t2, t3, t3, t1, t1, t2, t3, t4, t4, t4)
-        ).reshape(-1)
-        j = np.column_stack(
-            (t2, t1, t3, t2, t1, t3, t4, t4, t4, t1, t2, t3)
-        ).reshape(-1)
+        i = np.column_stack((t1, t2, t2, t3, t3, t1, t1, t2, t3, t4, t4, t4)).reshape(
+            -1
+        )
+        j = np.column_stack((t2, t1, t3, t2, t1, t3, t4, t4, t4, t1, t2, t3)).reshape(
+            -1
+        )
         adj = sparse.csc_matrix((np.ones(i.shape), (i, j)))
         return adj
 

--- a/lapy/TriaIO.py
+++ b/lapy/TriaIO.py
@@ -71,13 +71,7 @@ def import_off(infile):
         return
     t = t[:, 1:]
     f.close()
-    print(
-        " --> DONE ( V: "
-        + str(v.shape[0])
-        + " , T: "
-        + str(t.shape[0])
-        + " )\n"
-    )
+    print(" --> DONE ( V: " + str(v.shape[0]) + " , T: " + str(t.shape[0]) + " )\n")
     return TriaMesh(v, t)
 
 
@@ -175,20 +169,10 @@ def import_vtk(infile):
                 tt.append(tria)
         t = np.array(tt)
     else:
-        print(
-            "[read: "
-            + line
-            + " expected POLYGONS or TRIANGLE_STRIPS] --> FAILED\n"
-        )
+        print("[read: " + line + " expected POLYGONS or TRIANGLE_STRIPS] --> FAILED\n")
         return
     f.close()
-    print(
-        " --> DONE ( V: "
-        + str(v.shape[0])
-        + " , T: "
-        + str(t.shape[0])
-        + " )\n"
-    )
+    print(" --> DONE ( V: " + str(v.shape[0]) + " , T: " + str(t.shape[0]) + " )\n")
     return TriaMesh(v, t)
 
 
@@ -312,9 +296,9 @@ def import_gmsh(infile):
             line = f.readline()
             num_nodes = int(line)
             if is_ascii:
-                points = numpy.fromfile(
-                    f, count=num_nodes * 4, sep=" "
-                ).reshape((num_nodes, 4))
+                points = numpy.fromfile(f, count=num_nodes * 4, sep=" ").reshape(
+                    (num_nodes, 4)
+                )
                 # The first number is the index
                 points = points[:, 1:]
             else:
@@ -333,9 +317,7 @@ def import_gmsh(infile):
             line = f.readline()
             assert line.strip() == "$EndNodes"
         else:
-            assert environ == "Elements", "Unknown environment '{}'.".format(
-                environ
-            )
+            assert environ == "Elements", "Unknown environment '{}'.".format(environ)
             # The first line is the number of elements
             line = f.readline()
             total_num_cells = int(line)
@@ -387,14 +369,10 @@ def import_gmsh(infile):
                     # assert num_tags >= 2
 
                     # read element data
-                    num_bytes = 4 * (
-                        num_elems0 * (1 + num_tags + num_nodes_per_elem)
-                    )
+                    num_bytes = 4 * (num_elems0 * (1 + num_tags + num_nodes_per_elem))
                     shape = (num_elems0, 1 + num_tags + num_nodes_per_elem)
                     b = f.read(num_bytes)
-                    data = numpy.fromstring(b, dtype=numpy.int32).reshape(
-                        shape
-                    )
+                    data = numpy.fromstring(b, dtype=numpy.int32).reshape(shape)
 
                     if t not in cells:
                         cells[t] = []
@@ -438,9 +416,7 @@ def import_gmsh(infile):
             cell_data = output_cell_data
 
     if has_additional_tag_data:
-        logging.warning(
-            "The file contains tag data that couldn't be processed."
-        )
+        logging.warning("The file contains tag data that couldn't be processed.")
 
     return points, cells, point_data, cell_data, field_data
 

--- a/lapy/TriaMesh.py
+++ b/lapy/TriaMesh.py
@@ -94,7 +94,7 @@ class TriaMesh:
         containing the triangle indices (only for non-manifold meshes)
         Operates only on triangles.
         :return:    Sparse CSC matrix
-                    Similar ot adj_dir, but stores the tria idx+1 instead
+                    Similar to adj_dir, but stores the tria idx+1 instead
                     of one in the matrix (allows lookup of vertex to tria).
         """
         if not self.is_oriented():
@@ -123,7 +123,7 @@ class TriaMesh:
         """
         Check if triangle mesh is manifold (no edges with >2 triangles)
         Operates only on triangles
-        :return:   manifold       bool True if no edges wiht > 2 triangles
+        :return:   manifold       bool True if no edges with > 2 triangles
         """
         return np.max(self.adj_sym.data) <= 2
 
@@ -330,11 +330,7 @@ class TriaMesh:
         # compute length (2*area)
         ln = np.sqrt(np.sum(n * n, axis=1))
         q = 2.0 * np.sqrt(3) * ln
-        es = (
-            (v1mv0 * v1mv0).sum(1)
-            + (v2mv1 * v2mv1).sum(1)
-            + (v0mv2 * v0mv2).sum(1)
-        )
+        es = (v1mv0 * v1mv0).sum(1) + (v2mv1 * v2mv1).sum(1) + (v0mv2 * v0mv2).sum(1)
         return q / es
 
     def boundary_loops(self):
@@ -483,9 +479,7 @@ class TriaMesh:
         # compute normals for each tria
         tnormals = self.tria_normals()
         # compute dot product of normals at each edge
-        sprod = np.sum(
-            tnormals[tids[:, 0], :] * tnormals[tids[:, 1], :], axis=1
-        )
+        sprod = np.sum(tnormals[tids[:, 0], :] * tnormals[tids[:, 1], :], axis=1)
         # compute unsigned angles (clamp to ensure range)
         angle = np.maximum(sprod, -1)
         angle = np.minimum(angle, 1)
@@ -545,9 +539,7 @@ class TriaMesh:
         # instead we find direction that aligns with vertex normals as first
         # the other two will be sorted later anyway
         vnormals = self.vertex_normals()
-        dprod = -np.abs(
-            np.squeeze(np.sum(evecs * vnormals[:, :, np.newaxis], axis=1))
-        )
+        dprod = -np.abs(np.squeeze(np.sum(evecs * vnormals[:, :, np.newaxis], axis=1)))
         i = np.argsort(dprod, axis=1)
         evals = np.take_along_axis(evals, i, axis=1)
         it = np.tile(i.reshape((vnum, 1, 3)), (1, 3, 1))
@@ -578,7 +570,7 @@ class TriaMesh:
 
     def curvature_tria(self, smoothit=3):
         """
-        Compute min and max curvature and directions (orthognal and in tria plane)
+        Compute min and max curvature and directions (orthogonal and in tria plane)
         for each triangle. First we compute these values on vertices and then smooth
         there. Finally they get mapped to the trias (averaging) and projected onto
         the triangle plane, and orthogonalized.
@@ -588,9 +580,7 @@ class TriaMesh:
                  c_min : min curvature on triangles
                  c_max : max curvature on triangles
         """
-        u_min, u_max, c_min, c_max, c_mean, c_gauss, normals = self.curvature(
-            smoothit
-        )
+        u_min, u_max, c_min, c_max, c_mean, c_gauss, normals = self.curvature(smoothit)
 
         # pool vertex functions (u_min and u_max) to triangles:
         tumin = self.map_vfunc_to_tfunc(u_min)
@@ -696,9 +686,7 @@ class TriaMesh:
             t2 = np.column_stack((self.t[:, 1], e2, e1))
             t3 = np.column_stack((self.t[:, 2], e3, e2))
             t4 = np.column_stack((e1, e2, e3))
-            tnew = np.reshape(
-                np.concatenate((t1, t2, t3, t4), axis=1), (-1, 3)
-            )
+            tnew = np.reshape(np.concatenate((t1, t2, t3, t4), axis=1), (-1, 3))
             # set new vertices and tria and re-init adj matrices
             self.__init__(vnew, tnew)
 
@@ -748,9 +736,7 @@ class TriaMesh:
             # make sure i < j
             ij[np.ix_(ndirij, [1, 0])] = ij[np.ix_(ndirij, [0, 1])]
             # remove rows with unique (boundary) edges (half-edges without partner)
-            u, ind, c = np.unique(
-                ij, axis=0, return_index=True, return_counts=True
-            )
+            u, ind, c = np.unique(ij, axis=0, return_index=True, return_counts=True)
             bidx = ind[c == 1]
             # assert remaining edges have two triangles: min = max =2
             # note if we have only a single triangle or triangle soup
@@ -857,9 +843,7 @@ class TriaMesh:
         :return:  tfunc          Function on trias vector or matrix (#t x N)
         """
         if self.v.shape[0] != vfunc.shape[0]:
-            raise ValueError(
-                "Error: length of vfunc needs to match number of vertices"
-            )
+            raise ValueError("Error: length of vfunc needs to match number of vertices")
         vfunc = np.array(vfunc) / 3.0
         tfunc = np.sum(vfunc[self.t], axis=1)
         return tfunc
@@ -878,9 +862,7 @@ class TriaMesh:
             vfunc = self.v
         vfunc = np.array(vfunc)
         if self.v.shape[0] != vfunc.shape[0]:
-            raise ValueError(
-                "Error: length of vfunc needs to match number of vertices"
-            )
+            raise ValueError("Error: length of vfunc needs to match number of vertices")
         areas = self.vertex_areas()[:, np.newaxis]
         adj = self.adj_sym.copy()
         # binarize:

--- a/lapy/utils/_config.py
+++ b/lapy/utils/_config.py
@@ -42,9 +42,7 @@ def sys_info(fid: Optional[IO] = None, developer: bool = False):
     out("\nDependencies info\n")
     out(f"{package}:".ljust(ljust) + version(package) + "\n")
     dependencies = [
-        elt.split(";")[0].rstrip()
-        for elt in requires(package)
-        if "extra" not in elt
+        elt.split(";")[0].rstrip() for elt in requires(package) if "extra" not in elt
     ]
     _list_dependencies_info(out, ljust, dependencies)
 
@@ -68,9 +66,7 @@ def sys_info(fid: Optional[IO] = None, developer: bool = False):
             _list_dependencies_info(out, ljust, dependencies)
 
 
-def _list_dependencies_info(
-    out: Callable, ljust: int, dependencies: List[str]
-):
+def _list_dependencies_info(out: Callable, ljust: int, dependencies: List[str]):
     """List dependencies names and versions."""
     for dep in dependencies:
         # handle dependencies with version specifiers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ include = ['lapy*']
 exclude = ['lapy*tests']
 
 [tool.black]
-line-length = 79
+line-length = 88
 target-version = ['py38']
 include = '\.pyi?$'
 extend-exclude = '''


### PR DESCRIPTION
For starter, a couple more changes following #16. I did end up mixing up slightly files from #10 and from #16, leading to some typos fixed here:
- line-length increased from 79 characters to the default 88. `black` run across the code-base again, modifying all the files to the correct line-length.
- `import_optional_dependency` which I did setup.. and then reverted by mistake when I reverted all the changes to the codebase added in #10. It is now correctly used to manage the optional dependency `sksparse`, raising an error message with the library name on pip and conda if `use_cholmod` is `True` and the dep. is missing.

------------------

Those fixes following #16 done, the main focus of this PR was documentation. I reformatted the docstring from `Solver.py` to match the numpy convention:

```
def foo(a: int, b: float) -> float:
    """Summary line in imperative mood ending with a dot.

    Short optional description.

    Parameters
    ----------
    a : int
        Parameter 'a' description.
    b : float
        Parameter 'b' description
    
    Returns
    -------
    x : float
        Return 'x' description
    
    Notes
    -----
    Additional notes and information.
    """
    x = a + b
    return x
```

The full convention can be found on the [`numpydoc` website](https://numpydoc.readthedocs.io/en/latest/format.html). One good aspect about this convention is that it is well understood by `sphinx`, used to build a documentation website for your projects.
Talking about `sphinx`, you'll notice the use of double backticks and of single backticks in the docstrings. Double backticks are used for formatting, usually of variables while single backticks are used for cross-referencing. e.g. `~lapy.TetMesh` encapsulated in single backticks (hard to render on GitHub..) will yield a link to the documentation of the class `TetMesh`.
One more point, another good practice to have is to describe the shape of fix length arrays, e.g. numpy arrays or tuples. For instance, `array of shape (2,)` or `tuple of shape (n_channels, )` or `array of shape (n_channels, n_samples)`.

Anyway, I've done it for the `Solver.py` file and class, which you can now use as a template for the rest, but I will not do it for the others. I am not super familiar with the mathematics used behind, and I am not the best person to document those classes and functions. 
The `Solver.py` file now follows the `numpy` convention, and `pydocstyle lapy/Sovler.py` does not raise any additional warnings. If you apply this convention to the other classes, we can add a documentation build workflow to automatically build and deploy the package documentation. Here is an [example workflow](https://github.com/mscheltienne/simple-stimuli/blob/main/.github/workflows/doc.yml) with the associated [website](https://mscheltienne.github.io/simple-stimuli/dev/index.html) (sandbox repository I use for testing). Note that `sphinx` supports module for bibliography and for mathematical expressions ;)