### PR TITLE
Fix cholmod and related issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ your choice:
 
 `python3 -m pip install --user --src /my/preferred/location --editable git+https://github.com/Deep-MI/Lapy.git#egg=lapy`
 
-Several functions, e.g. the Solver, require a sparse matrix decomposition, for which either the LU decomposition (from scipy sparse) or the faster Cholesky decomposition (from scikit-sparse cholmod) can be used. If the parameter flag use_cholmod is True, the code will try to import cholmod from the scikit-sparse package and will fall back to LU if the import fails. If you would like to use cholmod, you need to install scikit-sparse separately. It cannot be listed among LaPy's dependencies as that causes errors with pip. scikit-sparse requires numpy and scipy to be installed separately beforehand.
+Several functions, e.g. the Solver, require a sparse matrix decomposition, for which either the LU decomposition (from scipy sparse) or the faster Cholesky decomposition (from scikit-sparse cholmod) can be used. The default is to use the LU decomposition. If the parameter flag use_cholmod is True, the code will try to import cholmod from the scikit-sparse package. If this fails, an error will be thrown. If you would like to use cholmod, you need to install scikit-sparse separately. It cannot be listed among LaPy's dependencies as that causes errors with pip. scikit-sparse requires numpy and scipy to be installed separately beforehand.
 
 ## References:
 

--- a/lapy/Conformal.py
+++ b/lapy/Conformal.py
@@ -12,6 +12,8 @@
 # SIAM Journal on Imaging Sciences, vol. 8, no. 1, pp. 67-94, 2015.
 
 
+import importlib
+
 import numpy as np
 from scipy import sparse
 from scipy.optimize import minimize
@@ -482,6 +484,7 @@ def sparse_symmetric_solve(A, b, use_cholmod=False):
 
     if use_cholmod:
         sksparse = import_optional_dependency("sksparse", raise_error=True)
+        importlib.import_module(".cholmod", sksparse.__name__)
     else:
         sksparse = None
     if use_cholmod:

--- a/lapy/Conformal.py
+++ b/lapy/Conformal.py
@@ -21,7 +21,7 @@ from .TriaMesh import TriaMesh
 from .utils._imports import import_optional_dependency
 
 
-def spherical_conformal_map(tria):
+def spherical_conformal_map(tria, use_cholmod=False):
     """
     A linear method for computing spherical conformal map of a genus-0 closed surface
 
@@ -29,6 +29,10 @@ def spherical_conformal_map(tria):
     ----------
     tria : TriaMesh
         vertices and faces
+    use_cholmod : bool, default=False
+        Which solver to use:
+            * True : Use Cholesky decomposition from scikit-sparse cholmod
+            * False: Use spsolve (LU decomposition)        
 
     Returns
     -------
@@ -104,7 +108,7 @@ def spherical_conformal_map(tria):
     rhs.real = c.flatten()
     rhs.imag = d.flatten()
 
-    z = sparse_symmetric_solve(M, rhs)
+    z = sparse_symmetric_solve(M, rhs, use_cholmod=use_cholmod)
     z = np.squeeze(np.array(z))
     z = z - np.mean(z, axis=0)
 
@@ -167,7 +171,7 @@ def spherical_conformal_map(tria):
     mu = beltrami_coefficient(triasouth, tria.v)
 
     # compose the map with another quasi-conformal map to cancel the distortion
-    mapping = linear_beltrami_solver(triasouth, mu, fixed, P[fixed, :])
+    mapping = linear_beltrami_solver(triasouth, mu, fixed, P[fixed, :], use_cholmod=use_cholmod)
 
     if np.isnan(np.sum(mapping)):
         # if the result has NaN entries, then most probably the number of
@@ -176,7 +180,7 @@ def spherical_conformal_map(tria):
         print("South pole compsed map has nan value(s)!")
         fixnum = fixnum * 5  # again, this number can be changed
         fixed = idx[0 : np.minimum(nv, fixnum)]
-        mapping = linear_beltrami_solver(triasouth, mu, fixed, P[fixed, :])
+        mapping = linear_beltrami_solver(triasouth, mu, fixed, P[fixed, :], use_cholmod=use_cholmod)
         if np.isnan(np.sum(mapping)):
             mapping = P  # use the old result
 
@@ -345,7 +349,7 @@ def beltrami_coefficient(tria, mapping):
     return mu
 
 
-def linear_beltrami_solver(tria, mu, landmark, target):
+def linear_beltrami_solver(tria, mu, landmark, target, use_cholmod=False):
     """
     Linear Beltrami solver
 
@@ -358,6 +362,10 @@ def linear_beltrami_solver(tria, mu, landmark, target):
     landmark : np.ndarray of fixed vertex indices
     target : np.ndarray of shape (n,3)
         2D landmark target coordinates (third coordinate is zero)
+    use_cholmod : bool, default=False
+        Which solver to use:
+            * True : Use Cholesky decomposition from scikit-sparse cholmod
+            * False: Use spsolve (LU decomposition)             
 
     Returns
     -------
@@ -447,14 +455,14 @@ def linear_beltrami_solver(tria, mu, landmark, target):
     A = A - Azero + Aones
     A.eliminate_zeros()
 
-    x = sparse_symmetric_solve(A, b)
+    x = sparse_symmetric_solve(A, b, use_cholmod=use_cholmod)
 
     mapping = np.squeeze(np.array(x))
     mapping = np.column_stack((np.real(mapping), np.imag(mapping)))
     return mapping
 
 
-def sparse_symmetric_solve(A, b, use_cholmod=True):
+def sparse_symmetric_solve(A, b, use_cholmod=False):
     """
     A sparse symmetric solver for ``A x = b``
 
@@ -462,7 +470,7 @@ def sparse_symmetric_solve(A, b, use_cholmod=True):
     ----------
     A : sparse matrix of shape (n, n)
     b : np.ndarray vector of length n
-    use_cholmod : bool, default=True
+    use_cholmod : bool, default=False
         Which solver to use:
             * True : Use Cholesky decomposition from scikit-sparse cholmod
             * False: Use spsolve (LU decomposition)
@@ -472,8 +480,11 @@ def sparse_symmetric_solve(A, b, use_cholmod=True):
     x: np.ndarray of length n, solution to  ``A x = b``
     """
 
-    sksparse = import_optional_dependency("sksparse", raise_error=use_cholmod)
-    if sksparse is not None:
+    if use_cholmod:
+        sksparse = import_optional_dependency("sksparse", raise_error=True)
+    else:
+        sksparse = None
+    if use_cholmod:
         print("Solver: Cholesky decomposition from scikit-sparse cholmod ...")
         chol = sksparse.cholmod.cholesky(A)
         x = chol(b)

--- a/lapy/DiffGeo.py
+++ b/lapy/DiffGeo.py
@@ -423,7 +423,7 @@ def tria_mean_curvature_flow(
     if use_cholmod:
         sksparse = import_optional_dependency("sksparse", raise_error=True)
     else:
-        skspare = None
+        sksparse = None
     # pre-normalize
     trianorm = TriaMesh(tria.v, tria.t)
     trianorm.normalize_()

--- a/lapy/DiffGeo.py
+++ b/lapy/DiffGeo.py
@@ -383,7 +383,7 @@ def tria_compute_rotated_f(tria, vfunc):
 
 
 def tria_mean_curvature_flow(
-    tria, max_iter=30, stop_eps=1e-13, step=1.0, use_cholmod=True
+    tria, max_iter=30, stop_eps=1e-13, step=1.0, use_cholmod=False
 ):
     """
     mean_curvature_flow iteratively flows a triangle mesh along mean curvature
@@ -405,7 +405,7 @@ def tria_mean_curvature_flow(
         stopping threshold
     step : float, default=1.0
         Euler step size
-    use_cholmod : bool, default=True
+    use_cholmod : bool, default=False
         Which solver to use:
             * True : Use Cholesky decomposition from scikit-sparse cholmod
             * False: Use spsolve (LU decomposition)
@@ -420,7 +420,10 @@ def tria_mean_curvature_flow(
     numexpr could speed up this functions if necessary
     """
 
-    sksparse = import_optional_dependency("sksparse", raise_error=use_cholmod)
+    if use_cholmod:
+        sksparse = import_optional_dependency("sksparse", raise_error=True)
+    else:
+        skspare = None
     # pre-normalize
     trianorm = TriaMesh(tria.v, tria.t)
     trianorm.normalize_()
@@ -435,7 +438,7 @@ def tria_mean_curvature_flow(
         mass = Solver.fem_tria_mass(trianorm, lump)
         mass_v = mass.dot(trianorm.v)
         # solve (M + step*A) * v = Mv and update vertices
-        if sksparse is not None:
+        if use_cholmod:
             print("Solver: Cholesky decomposition from scikit-sparse cholmod ...")
             factor = sksparse.cholmod.cholesky(mass + step * a_mat)
             trianorm.v = factor(mass_v)

--- a/lapy/DiffGeo.py
+++ b/lapy/DiffGeo.py
@@ -1,4 +1,5 @@
 import numpy as np
+import importlib
 from scipy import sparse
 
 from .Solver import Solver
@@ -422,6 +423,7 @@ def tria_mean_curvature_flow(
 
     if use_cholmod:
         sksparse = import_optional_dependency("sksparse", raise_error=True)
+        importlib.import_module(".cholmod", sksparse.__name__)
     else:
         sksparse = None
     # pre-normalize

--- a/lapy/Heat.py
+++ b/lapy/Heat.py
@@ -1,3 +1,5 @@
+import importlib
+
 import numpy as np
 
 from .utils._imports import import_optional_dependency
@@ -96,6 +98,7 @@ def diffusion(geometry, vids, m=1.0, aniso=None, use_cholmod=False):
 
     if use_cholmod:
         sksparse = import_optional_dependency("sksparse", raise_error=True)
+        importlib.import_module(".cholmod", sksparse.__name__)
     else:
         sksparse = None
     from .Solver import Solver

--- a/lapy/ShapeDNA.py
+++ b/lapy/ShapeDNA.py
@@ -8,7 +8,7 @@ from .TriaMesh import TriaMesh  # noqa: F401
 # compute shapeDNA
 
 
-def compute_shapedna(geom, k=50, lump=False, aniso=None, aniso_smooth=10):
+def compute_shapedna(geom, k=50, lump=False, aniso=None, aniso_smooth=10, use_cholmod=False):
     """
     a function to compute the shapeDNA descriptor for triangle or tetrahedral
     meshes
@@ -28,6 +28,11 @@ def compute_shapedna(geom, k=50, lump=False, aniso=None, aniso_smooth=10):
     aniso_smooth : int
         Number of smoothing iterations for curvature computation on vertices.
             (See 'lapy.Solver.Solver' class)
+    use_cholmod : bool, default: False
+        If True, attempts to use the Cholesky decomposition for improved execution
+        speed. Requires the ``scikit-sparse`` library. If it can not be found, an error 
+        will be thrown.
+        If False, will use slower LU decomposition.            
 
     Returns
     -------
@@ -37,7 +42,7 @@ def compute_shapedna(geom, k=50, lump=False, aniso=None, aniso_smooth=10):
 
     # get fem, evals, evecs
 
-    fem = Solver(geom, lump=lump, aniso=aniso, aniso_smooth=aniso_smooth)
+    fem = Solver(geom, lump=lump, aniso=aniso, aniso_smooth=aniso_smooth, use_cholmod=use_cholmod)
     evals, evecs = fem.eigs(k=k)
 
     # write ev

--- a/lapy/Solver.py
+++ b/lapy/Solver.py
@@ -1,4 +1,5 @@
 import sys
+import importlib
 from typing import Optional, Tuple, Union
 
 import numpy as np
@@ -55,6 +56,7 @@ class Solver:
     ) -> None:
         if use_cholmod:
             self.sksparse = import_optional_dependency("sksparse", raise_error=True)
+            importlib.import_module(".cholmod", self.sksparse.__name__)
         else:
             self.sksparse = None
         if type(geometry).__name__ == "TriaMesh":

--- a/lapy/Solver.py
+++ b/lapy/Solver.py
@@ -756,9 +756,9 @@ class Solver:
             a = self.stiffness
         # solve A x = b
         print("Matrix Format now: " + a.getformat())
-        if self.sparse is not None:
+        if self.sksparse is not None:
             print("Solver: Cholesky decomposition from scikit-sparse cholmod ...")
-            chol = self.sparse.cholesky(a)
+            chol = self.sksparse.cholmod.cholesky(a)
             x = chol(b)
         else:
             from scipy.sparse.linalg import splu


### PR DESCRIPTION
This pull request intends to solve the following issues:
- use of scipy.sparse instead of scikit-sparse
- inconsistent defininition and behavior of use_cholmod flag
- incomplete import of sksparse.cholmod  

It also changes the behavior of the use_cholmod flag: 
- if set to true and if scikit-sparse import fails, will no longer fall back to LU decomposition, but throw an error
- use_cholmod is now set to false by default, i.e. LU decomposition will be used by default

Minor changes:
- added use_cholmod argument to ShapeDNA and other submodules
- fixed eigsh import issue
- updated readme