### PR TITLE
Fix typos

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -214,7 +214,7 @@ def linkcode_resolve(domain: str, info: Dict[str, str]) -> Optional[str]:
         branch = "main"
     else:
         return None  # alternatively, link to a maint/version branch
-    fname = fname.split(f"/{package}/")[1]
+    fname = fname.rsplit(f"/{package}/")[1]
     url = f"{gh_url}/blob/{branch}/{package}/{fname}#{lines}"
     return url
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,8 @@ full = [
 ]
 
 [project.urls]
-homepage = 'https://github.com/Deep-MI/LaPy'
-documentation = 'https://github.com/Deep-MI/LaPy'
+homepage = 'https://Deep-MI.github.io/LaPy/dev/index.html'
+documentation = 'https://Deep-MI.github.io/LaPy/dev/index.html'
 source = 'https://github.com/Deep-MI/LaPy'
 tracker = 'https://github.com/Deep-MI/LaPy/issues'
 


### PR DESCRIPTION
2 typos to fix:
- a left split *can sometimes* cause problems in the function used to link a class/function to its code on GitHub
- the links in `pyproject.toml` were not updated