### PR TITLE
Fix documentation build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ instance/
 .scrapy
 
 # Sphinx documentation
+doc/bin
 doc/_build/
 doc/generated/
 doc/api/generated/

--- a/doc/_static/css/style.css
+++ b/doc/_static/css/style.css
@@ -1,0 +1,4 @@
+div.sphx-glr-download-link-note {
+  height: 0px;
+  visibility: hidden;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -76,6 +76,9 @@ default_role = "py:obj"
 # -- options for HTML output -------------------------------------------------
 html_theme = "furo"
 html_static_path = ["_static"]
+html_css_files = [
+    "css/style.css",
+]
 html_title = project
 html_show_sphinx = False
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -53,7 +53,13 @@ extensions = [
 ]
 
 templates_path = ["_templates"]
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints", "tutorials/examples/README.rst"]
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    "**.ipynb_checkpoints",
+    "tutorials/examples/README.rst",
+]
 
 # Sphinx will warn about all references where the target cannot be found.
 nitpicky = True

--- a/lapy/utils/_config.py
+++ b/lapy/utils/_config.py
@@ -52,6 +52,7 @@ def sys_info(fid: Optional[IO] = None, developer: bool = False):
         keys = (
             "build",
             "chol",
+            "doc",
             "test",
             "style",
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ chol = [
     'scikit-sparse',
 ]
 doc = [
-    'furo',
+    'furo==2023.5.20',
     'matplotlib',
     'memory-profiler',
     'numpydoc',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,11 @@ chol = [
     'scikit-sparse',
 ]
 doc = [
-    'furo==2023.5.20',
+    'furo',
     'matplotlib',
     'memory-profiler',
     'numpydoc',
-    'sphinx',
+    'sphinx<=7.0.1',
     'sphinxcontrib-bibtex',
     'sphinx-copybutton',
     'sphinx-design',


### PR DESCRIPTION
Let's try to figure that one out. Glad you've been tuning the build to your liking.

You have here some information on the installed package version: https://github.com/Deep-MI/LaPy/actions/runs/5400860203/job/14621909085 Sadly, the documentation dependencies are missing.. adding that here.