### PR TITLE
Fix documentation build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,11 @@ chol = [
     'scikit-sparse',
 ]
 doc = [
-    'furo',
+    'furo!=2023.8.17',
     'matplotlib',
     'memory-profiler',
     'numpydoc',
-    'sphinx<=7.0.1',
+    'sphinx!=7.2.*',
     'sphinxcontrib-bibtex',
     'sphinx-copybutton',
     'sphinx-design',


### PR DESCRIPTION
Attempt number 2, for some reason the PR and main did not install the same version of `furo`..
Note that incompatibilities such as those between theme/sphinx are rare but not uncommon. For instance, in MNE-Python using `pydata-sphinx-theme`, the theme is pinned to a specific version updated manually after we confirm that it builds correctly and still looks OK.

