### PR TITLE
Update read geometry

### DIFF
--- a/lapy/_read_geometry.py
+++ b/lapy/_read_geometry.py
@@ -148,7 +148,7 @@ def read_geometry(filepath, read_metadata=False, read_stamp=False):
 
     # See comment in _fread3 on why 
     #TRIANGLE_MAGIC = 16777214
-    TRIANGLE_MAGIC = [np.uint8(255), np.uint8(255), np.uint8(254)]
+    TRIANGLE_MAGIC = (np.uint8(255), np.uint8(255), np.uint8(254))
 
     with open(filepath, "rb") as fobj:
         magic = _fread3(fobj)

--- a/lapy/_read_geometry.py
+++ b/lapy/_read_geometry.py
@@ -146,7 +146,8 @@ def read_geometry(filepath, read_metadata=False, read_stamp=False):
     """
     volume_info = OrderedDict()
 
-    # See comment in _fread3 on why 
+    # See comment in _fread3() on why we have changed the
+    # comparison
     #TRIANGLE_MAGIC = 16777214
     TRIANGLE_MAGIC = (np.uint8(255), np.uint8(255), np.uint8(254))
 

--- a/lapy/_read_geometry.py
+++ b/lapy/_read_geometry.py
@@ -148,12 +148,13 @@ def read_geometry(filepath, read_metadata=False, read_stamp=False):
 
     # See comment in _fread3 on why 
     #TRIANGLE_MAGIC = 16777214
-    print("magic")
-    print(magic)
     TRIANGLE_MAGIC = [255, 255, 254]
 
     with open(filepath, "rb") as fobj:
         magic = _fread3(fobj)
+        print("magic")
+        print(magic)
+        print(magic)
 
         if magic == TRIANGLE_MAGIC:  # Triangle file
             create_stamp = fobj.readline().rstrip(b"\n").decode("utf-8")

--- a/lapy/_read_geometry.py
+++ b/lapy/_read_geometry.py
@@ -148,6 +148,8 @@ def read_geometry(filepath, read_metadata=False, read_stamp=False):
 
     # See comment in _fread3 on why 
     #TRIANGLE_MAGIC = 16777214
+    print("magic")
+    print(magic)
     TRIANGLE_MAGIC = [255, 255, 254]
 
     with open(filepath, "rb") as fobj:

--- a/lapy/_read_geometry.py
+++ b/lapy/_read_geometry.py
@@ -148,7 +148,7 @@ def read_geometry(filepath, read_metadata=False, read_stamp=False):
 
     # See comment in _fread3 on why 
     #TRIANGLE_MAGIC = 16777214
-    TRIANGLE_MAGIC = [255, 255, 254]
+    TRIANGLE_MAGIC = [np.uint8(255), np.uint8(255), np.uint8(254)]
 
     with open(filepath, "rb") as fobj:
         magic = _fread3(fobj)

--- a/lapy/_read_geometry.py
+++ b/lapy/_read_geometry.py
@@ -153,9 +153,6 @@ def read_geometry(filepath, read_metadata=False, read_stamp=False):
 
     with open(filepath, "rb") as fobj:
         magic = _fread3(fobj)
-        print("magic")
-        print(magic)
-        print(magic)
 
         if magic == TRIANGLE_MAGIC:  # Triangle file
             create_stamp = fobj.readline().rstrip(b"\n").decode("utf-8")

--- a/lapy/_read_geometry.py
+++ b/lapy/_read_geometry.py
@@ -53,11 +53,11 @@ def _fread3(fobj):
         A 3 byte int
     """
     b1, b2, b3 = np.fromfile(fobj, ">u1", 3)
-    # the bit-shifting operator does not return 
+    # the bit-shifting operator does not return
     # identical results on all platforms, therefore
-    # we disable it and return / compare the first 
+    # we disable it and return / compare the first
     # three bytes separately
-    #return (b1 << 16) + (b2 << 8) + b3
+    # return (b1 << 16) + (b2 << 8) + b3
     return b1, b2, b3
 
 
@@ -148,7 +148,7 @@ def read_geometry(filepath, read_metadata=False, read_stamp=False):
 
     # See comment in _fread3() on why we have changed the
     # comparison
-    #TRIANGLE_MAGIC = 16777214
+    # TRIANGLE_MAGIC = 16777214
     TRIANGLE_MAGIC = (np.uint8(255), np.uint8(255), np.uint8(254))
 
     with open(filepath, "rb") as fobj:

--- a/lapy/_read_geometry.py
+++ b/lapy/_read_geometry.py
@@ -53,7 +53,12 @@ def _fread3(fobj):
         A 3 byte int
     """
     b1, b2, b3 = np.fromfile(fobj, ">u1", 3)
-    return (b1 << 16) + (b2 << 8) + b3
+    # the bit-shifting operator does not return 
+    # identical results on all platforms, therefore
+    # we disable it and return / compare the first 
+    # three bytes separately
+    #return (b1 << 16) + (b2 << 8) + b3
+    return b1, b2, b3
 
 
 def _read_volume_info(fobj):
@@ -141,7 +146,9 @@ def read_geometry(filepath, read_metadata=False, read_stamp=False):
     """
     volume_info = OrderedDict()
 
-    TRIANGLE_MAGIC = 16777214
+    # See comment in _fread3 on why 
+    #TRIANGLE_MAGIC = 16777214
+    TRIANGLE_MAGIC = [255, 255, 254]
 
     with open(filepath, "rb") as fobj:
         magic = _fread3(fobj)


### PR DESCRIPTION
This PR changes the magic number that is used to assess the validity of presumed FreeSurfer surface files. 

Previously, the computation of the magic number involved the application of the bit-shifting operator; however, this does not return identical results on all platforms. We therefore we disable it and return / compare the first three bytes of the file separately.