### PR TITLE
Fix rotate and poisson

### DIFF
--- a/lapy/diffgeo.py
+++ b/lapy/diffgeo.py
@@ -367,7 +367,7 @@ def tria_compute_rotated_f(tria, vfunc):
     # div is the integrated divergence (so it is already B*div)
     fem.mass = sparse.eye(fem.stiffness.shape[0], dtype=vfunc.dtype)
     # since the solution is ill defined (addition of constant)
-    # we specify an arbitary boundary condition at a single vertex to
+    # we specify an arbitrary boundary condition at a single vertex to
     # remove that degree of freedom
     dtup = ( np.array([0]), np.array([0.0]))
     vf = fem.poisson(divf,dtup)

--- a/lapy/diffgeo.py
+++ b/lapy/diffgeo.py
@@ -366,7 +366,11 @@ def tria_compute_rotated_f(tria, vfunc):
     #   we can pass identity instead of B here:
     # div is the integrated divergence (so it is already B*div)
     fem.mass = sparse.eye(fem.stiffness.shape[0], dtype=vfunc.dtype)
-    vf = fem.poisson(divf)
+    # since the solution is ill defined (addition of constant)
+    # we specify an arbitary boundary condition at a single vertex to
+    # remove that degree of freedom
+    dtup = ( np.array([0]), np.array([0.0]))
+    vf = fem.poisson(divf,dtup)
     return vf
 
 

--- a/lapy/plot.py
+++ b/lapy/plot.py
@@ -171,7 +171,7 @@ def _get_colorval(t, colormap):
     # compute new color via linear interpolation
     cval = np.rint(rv1 + tt * (rv2 - rv1)).astype(int)
     # format as string again
-    cstr = "rgb(%d, %d, %d)" % (cval[0], cval[1], cval[2])
+    cstr = f"rgb({cval[0]:d}, {cval[1]:d}, {cval[2]:d})"
     return cstr
 
 

--- a/lapy/solver.py
+++ b/lapy/solver.py
@@ -705,6 +705,8 @@ class Solver:
             raise ValueError(
                 "h should be either scalar or column vector with row num of A"
             )
+        if h.ndim == 1:
+            h = h[:,np.newaxis]
         # create vector d
         didx = []
         dvec = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'lapy'
-version = '1.2.0-dev'
+version = '1.1.2'
 description = 'A package for differential geometry on meshes (Laplace, FEM)'
 readme = 'README.md'
 license = {file = 'LICENSE'}


### PR DESCRIPTION
1. when computing a function with rotated gradients, the problem was singular due to the degree of freedom to shift the function (addition of constant). This can be fixed by specifying an arbitrary dirichlet boundary condition at a vertex (here: 0, 0.0). 
2. in poisson, when a function h was passed in connection with a dirichlet boundary condition, the function h needs to be a 2D matrix with a single column instead of a 1-dim vector. So we add a new axis. 