### PR TITLE
return edge indices and ratios for levelpaths

### DIFF
--- a/lapy/tria_mesh.py
+++ b/lapy/tria_mesh.py
@@ -1430,7 +1430,7 @@ class TriaMesh:
                 raise ValueError("n_points cannot be combined with get_tria_idx=True.")
             tria_idx = tria_idx[dd[:-1] > eps]
             if get_edges:
-                return path3d, llength, edges_vidxs, edges_relpos, tria_idx
+                return path3d, llength, tria_idx, edges_vidxs, edges_relpos
             else:
                 return path3d, llength, tria_idx
         else:

--- a/lapy/tria_mesh.py
+++ b/lapy/tria_mesh.py
@@ -1328,7 +1328,7 @@ class TriaMesh:
             edge (i,j) from the original mesh, default False.
         n_points : int
             Resample level set into n equidistant points. Cannot be combined
-            with get_tria_idx=True nor with get_vertex_idx=True.
+            with get_tria_idx=True nor with get_edges=True.
 
         Returns
         -------

--- a/lapy/tria_mesh.py
+++ b/lapy/tria_mesh.py
@@ -1322,7 +1322,7 @@ class TriaMesh:
             Level set value.
         get_tria_idx : bool, default: False
             Also return a list of triangle indices for each edge, default False.
-        get_edges: bool, default: False
+        get_edges : bool, default: False
             Also return a list of two vertex indices (i,j) for each 3D point and
             a list of the relative position defining the 3D point along that
             edge (i,j) from the original mesh, default False.


### PR DESCRIPTION
This feature by @m-reuter returns the edges that intersect a levelpath and where on the edge the intersection happened. Users can then insert the levelpath as vertices on a triangle mesh or create a distinct object from the path segments.

I tested the code and it works