### PR TITLE
Update numpy and scikit-sparse version constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 dependencies = [
     'nibabel',
-    'numpy>=1.21',
+    'numpy>=2',
     'plotly',
     'psutil',
     'scipy!=1.13.0',
@@ -56,7 +56,7 @@ build = [
     'twine',
 ]
 chol = [
-    'scikit-sparse',
+    'scikit-sparse>=0.4.16',
 ]
 doc = [
     'furo!=2023.8.17',


### PR DESCRIPTION
Bump numpy constraint to version 2 and scikit-sparse to 0.4.16, which now supports numpy 2.0 for newer pythons versions.