### PR TITLE
Solver.poisson support pre-integrated vfuncs

### DIFF
--- a/lapy/diffgeo.py
+++ b/lapy/diffgeo.py
@@ -146,8 +146,9 @@ def compute_geodesic_f(
 
     gradf = compute_gradient(geom, vfunc)
     fem = Solver(geom, lump=True, use_cholmod=use_cholmod)
-    # fem.mass = sparse.eye(fem.stiffness.shape[0], dtype=fem.stiffness.dtype)
 
+    # divf is the integrated divergence (so it is already B*div)
+    # we can solve by passing in integrate=False to avoid multiplying with B again
     if scalar_input:
         # gradf: (n_elements, 3)
         gradnorm = gradf / np.sqrt((gradf**2).sum(1))[:, np.newaxis]
@@ -198,10 +199,9 @@ def tria_compute_geodesic_f(
 
     gradf = tria_compute_gradient(tria, vfunc)
     fem = Solver(tria, lump=True, use_cholmod=use_cholmod)
-    # div is the integrated divergence (so it is already B*div);
-    # pass identity instead of B here
-    # fem.mass = sparse.eye(fem.stiffness.shape[0])
 
+    # divf is the integrated divergence (so it is already B*div)
+    # we can solve by passing in integrate=False to avoid multiplying with B again
     if scalar_input:
         # gradf: (n_triangles, 3)
         gradnorm = gradf / np.sqrt((gradf**2).sum(1))[:, np.newaxis]
@@ -503,9 +503,10 @@ def tria_compute_rotated_f(
     gradf = tria_compute_gradient(tria, vfunc)
     tn = tria.tria_normals()
     fem = Solver(tria, lump=True, use_cholmod=use_cholmod)
-    # fem.mass = sparse.eye(fem.stiffness.shape[0], dtype=vfunc.dtype)
     dtup = (np.array([0]), np.array([0.0]))
-
+    
+    # divf is the integrated divergence (so it is already B*div)
+    # we can solve by passing in integrate=False to avoid multiplying with B again
     if scalar_input:
         # gradf: (n_triangles, 3)
         gradf = np.cross(tn, gradf)

--- a/lapy/diffgeo.py
+++ b/lapy/diffgeo.py
@@ -146,21 +146,21 @@ def compute_geodesic_f(
 
     gradf = compute_gradient(geom, vfunc)
     fem = Solver(geom, lump=True, use_cholmod=use_cholmod)
-    fem.mass = sparse.eye(fem.stiffness.shape[0], dtype=fem.stiffness.dtype)
+    # fem.mass = sparse.eye(fem.stiffness.shape[0], dtype=fem.stiffness.dtype)
 
     if scalar_input:
         # gradf: (n_elements, 3)
         gradnorm = gradf / np.sqrt((gradf**2).sum(1))[:, np.newaxis]
         gradnorm = np.nan_to_num(gradnorm)
         divf = compute_divergence(geom, gradnorm)
-        vf = fem.poisson(divf)
+        vf = fem.poisson(divf, integrate=False)
         vf -= vf.min()
     else:
         # gradf: (n_elements, n_functions, 3) — norm along last axis
         gradnorm = gradf / np.sqrt((gradf**2).sum(-1))[:, :, np.newaxis]
         gradnorm = np.nan_to_num(gradnorm)
         divf = compute_divergence(geom, gradnorm)  # (n_vertices, n_functions)
-        vf = fem.poisson(divf)                     # (n_vertices, n_functions)
+        vf = fem.poisson(divf, integrate=False)     # (n_vertices, n_functions)
         vf -= vf.min(axis=0)
     return vf
 
@@ -200,21 +200,21 @@ def tria_compute_geodesic_f(
     fem = Solver(tria, lump=True, use_cholmod=use_cholmod)
     # div is the integrated divergence (so it is already B*div);
     # pass identity instead of B here
-    fem.mass = sparse.eye(fem.stiffness.shape[0])
+    # fem.mass = sparse.eye(fem.stiffness.shape[0])
 
     if scalar_input:
         # gradf: (n_triangles, 3)
         gradnorm = gradf / np.sqrt((gradf**2).sum(1))[:, np.newaxis]
         gradnorm = np.nan_to_num(gradnorm)
         divf = tria_compute_divergence(tria, gradnorm)
-        vf = fem.poisson(divf)
+        vf = fem.poisson(divf, integrate=False)
         vf -= vf.min()
     else:
         # gradf: (n_triangles, n_functions, 3) — norm along last axis
         gradnorm = gradf / np.sqrt((gradf**2).sum(-1))[:, :, np.newaxis]
         gradnorm = np.nan_to_num(gradnorm)
         divf = tria_compute_divergence(tria, gradnorm)  # (n_vertices, n_functions)
-        vf = fem.poisson(divf)                          # (n_vertices, n_functions)
+        vf = fem.poisson(divf, integrate=False)          # (n_vertices, n_functions)
         vf -= vf.min(axis=0)
     return vf
 
@@ -503,20 +503,20 @@ def tria_compute_rotated_f(
     gradf = tria_compute_gradient(tria, vfunc)
     tn = tria.tria_normals()
     fem = Solver(tria, lump=True, use_cholmod=use_cholmod)
-    fem.mass = sparse.eye(fem.stiffness.shape[0], dtype=vfunc.dtype)
+    # fem.mass = sparse.eye(fem.stiffness.shape[0], dtype=vfunc.dtype)
     dtup = (np.array([0]), np.array([0.0]))
 
     if scalar_input:
         # gradf: (n_triangles, 3)
         gradf = np.cross(tn, gradf)
         divf = tria_compute_divergence(tria, gradf)
-        vf = fem.poisson(divf, dtup)
+        vf = fem.poisson(divf, dtup, integrate=False)
     else:
         # gradf: (n_triangles, n_functions, 3)
         # tn: (n_triangles, 3) -> broadcast via (n_triangles, 1, 3)
         gradf = np.cross(tn[:, np.newaxis, :], gradf)  # (n_triangles, n_functions, 3)
         divf = tria_compute_divergence(tria, gradf)    # (n_vertices, n_functions)
-        vf = fem.poisson(divf, dtup)                   # (n_vertices, n_functions)
+        vf = fem.poisson(divf, dtup, integrate=False)   # (n_vertices, n_functions)
     return vf
 
 

--- a/lapy/solver.py
+++ b/lapy/solver.py
@@ -784,6 +784,7 @@ class Solver:
         h: float | np.ndarray = 0.0,
         dtup: tuple = (),
         ntup: tuple = (),
+        integrate: bool = True,
     ) -> np.ndarray:
         """Solver for the Poisson equation with boundary conditions.
 
@@ -808,6 +809,11 @@ class Solver:
             Neumann boundary condition as a tuple containing the index and
             data arrays of same length. The default, an empty tuple,
             corresponds to Neumann on all boundaries.
+        integrate: bool, default=True
+            Whether to integrate the right hand side over the surface using 
+            the mass matrix. If True, the right hand side is effectively 
+            replaced by ``B h``. If False, the right hand side is used as is, 
+            which corresponds to ``A x = h``. 
 
         Returns
         -------
@@ -904,8 +910,9 @@ class Solver:
                 (dim, n_rhs), dtype=dtype
             )
         # compute right hand side
-        mass = self.mass.astype(dtype, copy=False)
-        b = mass * (h - nvec)
+        b = h - nvec
+        if integrate:
+            b = self.mass.astype(dtype, copy=False) * b
         if len(didx) > 0:
             b = b - self.stiffness * dvec
         # remove Dirichlet Nodes

--- a/lapy/solver.py
+++ b/lapy/solver.py
@@ -791,7 +791,8 @@ class Solver:
         This solver is based on the ``A`` and ``B`` Laplace matrices where
         ``A x = B h`` and ``A`` is a sparse symmetric positive semi-definite
         matrix of shape ``(n, n)`` and B is a sparse symmetric positive
-        definite matrix of shape ``(n, n)``.
+        definite matrix of shape ``(n, n)`` (use ``integrate=False`` to solve
+        ``A x = h`` instead).
 
         Parameters
         ----------
@@ -809,11 +810,12 @@ class Solver:
             Neumann boundary condition as a tuple containing the index and
             data arrays of same length. The default, an empty tuple,
             corresponds to Neumann on all boundaries.
-        integrate: bool, default=True
-            Whether to integrate the right hand side over the surface using 
-            the mass matrix. If True, the right hand side is effectively 
-            replaced by ``B h``. If False, the right hand side is used as is, 
-            which corresponds to ``A x = h``. 
+        integrate : bool, default=True
+            Whether to integrate the right hand side over the surface using
+            the mass matrix (after applying any Neumann conditions, but before
+            applying Dirichlet conditions). If True, the right hand side is
+            effectively replaced by ``B h``. If False, the right hand side is
+            used as is, which corresponds to ``A x = h``.
 
         Returns
         -------

--- a/lapy/utils/tests/test_solver.py
+++ b/lapy/utils/tests/test_solver.py
@@ -1,8 +1,8 @@
 """Tests for Solver.eigs and Solver.poisson — parameters and 2-D rhs support."""
 
 import numpy as np
-from scipy import sparse
 import pytest
+from scipy import sparse
 
 from ...solver import Solver
 from ...tria_mesh import TriaMesh

--- a/lapy/utils/tests/test_solver.py
+++ b/lapy/utils/tests/test_solver.py
@@ -1,6 +1,7 @@
 """Tests for Solver.eigs and Solver.poisson — parameters and 2-D rhs support."""
 
 import numpy as np
+from scipy import sparse
 import pytest
 
 from ...solver import Solver
@@ -100,3 +101,19 @@ def test_poisson_2d_rhs_with_dirichlet(tria_mesh):
             err_msg=f"poisson 2-D Dirichlet mismatch at column {k}",
         )
 
+def test_poisson_with_integrate_false(tria_mesh):
+    """poisson with integrate=False must solve A x = h, not A x = B h."""
+    fem1 = Solver(tria_mesh, lump=True)
+    _, evec = fem1.eigs(k=5)
+    rhs = evec[:, 1:4]  # (n_vertices, 3)
+
+    res1 = fem1.poisson(rhs, integrate=False)
+
+    fem2 = Solver(tria_mesh, lump=True)
+    fem2.mass = sparse.eye(fem2.stiffness.shape[0], dtype=fem2.stiffness.dtype)
+    res2 = fem2.poisson(rhs, integrate=True)
+
+    np.testing.assert_allclose(
+        res1, res2, rtol=1e-6, atol=1e-9,
+        err_msg="poisson with integrate=False does not match poisson with identity mass matrix",
+    )


### PR DESCRIPTION
- `Solver.poisson` always multiplies the input vfunc `h` by `self.mass` to generate an integrated map
- This creates difficulties when solving for different maps, where some are integrated, and some are not: a new Solver object has to be created and its mass set to the identity
- It is easier to create a flag where the user can specify if the map is already integrated or not. This is what I have done here. 
- This also simplifies the code in `diffgeo.compute_geodesic_f` etc. 
- The default behaviour is preserved
- The figures in `Test_TriaMesh_Geodesics.ipynb` still look good when `vf = fem.poisson(Bi * divx)` is replaced by `vf = fem.poisson(divx, integrate=False)`